### PR TITLE
add scrollbar to text field

### DIFF
--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -10,6 +10,7 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:background="@null"
-        android:gravity="top"/>
+        android:gravity="top"
+        android:scrollbars="vertical"/>
 
 </RelativeLayout>


### PR DESCRIPTION
So app bar doesn't scroll off screen. It's a *huge* QoL improvement. For example, right now you can't select all -> cut/copy because those controls are off the screen.

Note: I made this PR via the github web interface so I've done absolutely zero testing.