### PR TITLE
Set applicationIdSuffix to ".debug"

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -19,6 +19,9 @@ android {
     }
 
     buildTypes {
+        debug {
+            applicationIdSuffix ".debug"
+        }
         release {
             minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'


### PR DESCRIPTION
The commit allows to have debug and release build installed side by side.

Currently it's hard to switch between release and debug build while developing: you need to backup all your notes somewhere one by one, then actually develop, send changes, then install release version again. A couple of weeks passes, you want something to be improved and go through all this mess again. You may ask me why can't I keep debug version installed. Here's why: something may break in an unstable version and cause notes to be lost.