### PR TITLE
Disable personalized learning when typing note text

### DIFF
--- a/app/src/main/res/layout/note_view_horiz_scrollable.xml
+++ b/app/src/main/res/layout/note_view_horiz_scrollable.xml
@@ -15,6 +15,7 @@
         android:freezesText="true"
         android:gravity="top"
         android:inputType="textCapSentences|textMultiLine"
+        android:imeOptions="flagNoPersonalizedLearning"
         android:padding="@dimen/activity_margin"
         android:scrollbars="vertical"
         android:textCursorDrawable="@null"/>

--- a/app/src/main/res/layout/note_view_static.xml
+++ b/app/src/main/res/layout/note_view_static.xml
@@ -8,6 +8,7 @@
     android:freezesText="true"
     android:gravity="top"
     android:inputType="textCapSentences|textMultiLine"
+    android:imeOptions="flagNoPersonalizedLearning"
     android:padding="@dimen/activity_margin"
     android:scrollbars="vertical"
     android:textCursorDrawable="@null"/>


### PR DESCRIPTION
Implement #217. According to [the documentation](https://developer.android.com/reference/android/view/inputmethod/EditorInfo#IME_FLAG_NO_PERSONALIZED_LEARNING) of the IME_FLAG_NO_PERSONALIZED_LEARNING

> Applications need to be aware that the flag is not a guarantee, and some IMEs may not respect it.

So, it's nice to have, but might not work in some cases.