### PR TITLE
Change the wording of the checklist sorting option

### DIFF
--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -48,7 +48,7 @@
     <string name="autosave_notes">Notizen automatisch speichern</string>
     <string name="enable_line_wrap">Zeilenumbruch aktivieren</string>
     <string name="use_incognito_mode">Benutze den Inkognitomodus von Tastaturen</string>
-    <string name="move_undone_checklist_items">Verschiebe rückgängig gemachte Checklisteneinträge nach oben</string>
+    <string name="move_undone_checklist_items">Verschiebe erledigte Checklisteneinträge nach unten</string>
 
     <!-- Checklists -->
     <string name="checklist">Checkliste</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -48,7 +48,7 @@
     <string name="autosave_notes">Autosave notes</string>
     <string name="enable_line_wrap">Enable line wrap</string>
     <string name="use_incognito_mode">Use Incognito mode of keyboards</string>
-    <string name="move_undone_checklist_items">Move undone checklist items at the top</string>
+    <string name="move_undone_checklist_items">Move done checklist items to the bottom</string>
 
     <!-- Checklists -->
     <string name="checklist">Checklist</string>


### PR DESCRIPTION
Imho, this change better reflects the intent of the option. I noticed it, because the German translation is incorrect. The translator apparently interpreted the 'undone' as 'reverted' (which can be right but does not fit in this context).