### PR TITLE
Checklist: quick drag&drop

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/notes/pro/adapters/ChecklistAdapter.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/notes/pro/adapters/ChecklistAdapter.kt
@@ -33,8 +33,6 @@ class ChecklistAdapter(activity: BaseSimpleActivity, var items: ArrayList<Checkl
                        recyclerView: MyRecyclerView, val showIcons: Boolean, itemClick: (Any) -> Unit) :
         MyRecyclerViewAdapter(activity, recyclerView, null, itemClick), ItemTouchHelperContract {
 
-    private lateinit var crossDrawable: Drawable
-    private lateinit var checkDrawable: Drawable
     private var touchHelper: ItemTouchHelper? = null
     private var startReorderDragListener: StartReorderDragListener
 
@@ -106,8 +104,6 @@ class ChecklistAdapter(activity: BaseSimpleActivity, var items: ArrayList<Checkl
 
     private fun initDrawables() {
         val res = activity.resources
-        crossDrawable = res.getColoredDrawableWithColor(R.drawable.ic_cross_vector, res.getColor(R.color.md_red_700))
-        checkDrawable = res.getColoredDrawableWithColor(R.drawable.ic_check_vector, res.getColor(R.color.md_green_700))
     }
 
     private fun renameChecklistItem() {
@@ -193,11 +189,9 @@ class ChecklistAdapter(activity: BaseSimpleActivity, var items: ArrayList<Checkl
                 }
             }
 
-            checklist_image.setImageDrawable(if (checklistItem.isDone) checkDrawable else crossDrawable)
-            checklist_image.beVisibleIf(showIcons)
             checklist_holder.isSelected = isSelected
 
-            checklist_drag_handle.beVisibleIf(selectedKeys.isNotEmpty())
+            checklist_drag_handle.beVisibleIf(showIcons)
             checklist_drag_handle.applyColorFilter(textColor)
             checklist_drag_handle.setOnTouchListener { v, event ->
                 if (event.action == MotionEvent.ACTION_DOWN) {

--- a/app/src/main/res/layout/item_checklist.xml
+++ b/app/src/main/res/layout/item_checklist.xml
@@ -18,21 +18,10 @@
         android:paddingStart="@dimen/activity_margin"
         android:textSize="@dimen/bigger_text_size"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toStartOf="@+id/checklist_image"
+        app:layout_constraintEnd_toStartOf="@+id/checklist_drag_handle"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         tools:text="Butter" />
-
-    <ImageView
-        android:id="@+id/checklist_image"
-        android:layout_width="@dimen/checklist_image_size"
-        android:layout_height="@dimen/checklist_image_size"
-        android:paddingTop="@dimen/normal_margin"
-        android:paddingBottom="@dimen/normal_margin"
-        android:src="@drawable/ic_cross_vector"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toStartOf="@+id/checklist_drag_handle"
-        app:layout_constraintTop_toTopOf="parent" />
 
     <ImageView
         android:id="@+id/checklist_drag_handle"
@@ -41,7 +30,7 @@
         android:paddingTop="@dimen/normal_margin"
         android:paddingBottom="@dimen/normal_margin"
         android:src="@drawable/ic_drag_handle_vector"
-        android:visibility="gone"
+        android:visibility="visible"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent" />


### PR DESCRIPTION
I'd like to make it a bit easier to rearrange items in a checklist by always showing the drag handle. Showing both the status icon and the handle all the time takes up a bit too much screen space, I think. Therefore I would remove the icon. As the text color and strike-through already provide good visual feedback, I think this no big loss to readability.
What do you think?