### PR TITLE
Fix editing previously exported notes not working properly

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/notes/pro/activities/MainActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/notes/pro/activities/MainActivity.kt
@@ -875,7 +875,7 @@ class MainActivity : SimpleActivity() {
 
     private fun exportNoteValueToUri(uri: Uri, content: String, callback: ((success: Boolean) -> Unit)? = null) {
         try {
-            val outputStream = contentResolver.openOutputStream(uri)
+            val outputStream = contentResolver.openOutputStream(uri, "wt")
             outputStream!!.bufferedWriter().use { out ->
                 out.write(content)
             }

--- a/app/src/main/kotlin/com/simplemobiletools/notes/pro/activities/MainActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/notes/pro/activities/MainActivity.kt
@@ -650,7 +650,8 @@ class MainActivity : SimpleActivity() {
         } else {
             val items = arrayListOf(
                 RadioItem(EXPORT_FILE_SYNC, getString(R.string.update_file_at_note)),
-                RadioItem(EXPORT_FILE_NO_SYNC, getString(R.string.only_export_file_content)))
+                RadioItem(EXPORT_FILE_NO_SYNC, getString(R.string.only_export_file_content))
+            )
 
             RadioGroupDialog(this, items) {
                 val syncFile = it as Int == EXPORT_FILE_SYNC
@@ -740,7 +741,8 @@ class MainActivity : SimpleActivity() {
     private fun showExportFilePickUpdateDialog(exportPath: String, textToExport: String) {
         val items = arrayListOf(
             RadioItem(EXPORT_FILE_SYNC, getString(R.string.update_file_at_note)),
-            RadioItem(EXPORT_FILE_NO_SYNC, getString(R.string.only_export_file_content)))
+            RadioItem(EXPORT_FILE_NO_SYNC, getString(R.string.only_export_file_content))
+        )
 
         RadioGroupDialog(this, items) {
             val syncFile = it as Int == EXPORT_FILE_SYNC
@@ -771,7 +773,8 @@ class MainActivity : SimpleActivity() {
         ExportFilesDialog(this, mNotes) { parent, extension ->
             val items = arrayListOf(
                 RadioItem(EXPORT_FILE_SYNC, getString(R.string.update_file_at_note)),
-                RadioItem(EXPORT_FILE_NO_SYNC, getString(R.string.only_export_file_content)))
+                RadioItem(EXPORT_FILE_NO_SYNC, getString(R.string.only_export_file_content))
+            )
 
             RadioGroupDialog(this, items) {
                 val syncFile = it as Int == EXPORT_FILE_SYNC
@@ -858,9 +861,7 @@ class MainActivity : SimpleActivity() {
                 }
             } else {
                 val file = File(path)
-                file.printWriter().use { out ->
-                    out.write(content)
-                }
+                file.writeText(content)
 
                 if (showSuccessToasts) {
                     noteExportedSuccessfully(path.getFilenameFromPath())


### PR DESCRIPTION
Addresses #423.

OutputStream for existing files with `content://` path needs to be opened in truncate mode, its description: "If the file already exists and is a regular file and is opened for writing, it will be truncated to length 0."
Streams for files with `/storage` path don't seem to be affected by this issue and don't need the truncate mode.

See more at https://developer.android.com/reference/android/os/ParcelFileDescriptor#parseMode(java.lang.String).