### PR TITLE
Remove note protection if biometric id is no longer available

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -56,7 +56,7 @@ android {
 }
 
 dependencies {
-    implementation 'com.github.SimpleMobileTools:Simple-Commons:dc3f4b619e'
+    implementation 'com.github.SimpleMobileTools:Simple-Commons:8979ca8187'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.0'
     implementation 'androidx.documentfile:documentfile:1.0.1'
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,8 +11,6 @@
         android:name="android.hardware.faketouch"
         android:required="false" />
 
-    <uses-permission android:name="android.permission.USE_BIOMETRIC" />
-
     <application
         android:name=".App"
         android:allowBackup="true"

--- a/app/src/main/kotlin/com/simplemobiletools/notes/pro/activities/MainActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/notes/pro/activities/MainActivity.kt
@@ -317,7 +317,7 @@ class MainActivity : SimpleActivity() {
 
     private fun initViewPager(wantedNoteId: Long? = null) {
         NotesHelper(this).getNotes { notes ->
-            notes.filter { it.isBiometricLockUnavailable(this) }
+            notes.filter { it.shouldBeUnlocked(this) }
                 .forEach(::removeProtection)
 
             mNotes = notes

--- a/app/src/main/kotlin/com/simplemobiletools/notes/pro/activities/MainActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/notes/pro/activities/MainActivity.kt
@@ -316,8 +316,11 @@ class MainActivity : SimpleActivity() {
     }
 
     private fun initViewPager(wantedNoteId: Long? = null) {
-        NotesHelper(this).getNotes {
-            mNotes = it
+        NotesHelper(this).getNotes { notes ->
+            notes.filter { it.isBiometricLockUnavailable(this) }
+                .forEach(::removeProtection)
+
+            mNotes = notes
             invalidateOptionsMenu()
             mCurrentNote = mNotes[0]
             mAdapter = NotesPagerAdapter(supportFragmentManager, mNotes, this)
@@ -1084,19 +1087,21 @@ class MainActivity : SimpleActivity() {
         performSecurityCheck(
             protectionType = mCurrentNote.protectionType,
             requiredHash = mCurrentNote.protectionHash,
-            successCallback = { _, _ -> removeProtection() }
+            successCallback = { _, _ -> removeProtection(mCurrentNote) }
         )
     }
 
-    private fun removeProtection() {
-        mCurrentNote.protectionHash = ""
-        mCurrentNote.protectionType = PROTECTION_NONE
-        NotesHelper(this).insertOrUpdateNote(mCurrentNote) {
-            getCurrentFragment()?.apply {
-                shouldShowLockedContent = true
-                checkLockState()
+    private fun removeProtection(note: Note) {
+        note.protectionHash = ""
+        note.protectionType = PROTECTION_NONE
+        NotesHelper(this).insertOrUpdateNote(note) {
+            if (note == mCurrentNote) {
+                getCurrentFragment()?.apply {
+                    shouldShowLockedContent = true
+                    checkLockState()
+                }
+                invalidateOptionsMenu()
             }
-            invalidateOptionsMenu()
         }
     }
 

--- a/app/src/main/kotlin/com/simplemobiletools/notes/pro/activities/WidgetConfigureActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/notes/pro/activities/WidgetConfigureActivity.kt
@@ -104,7 +104,7 @@ class WidgetConfigureActivity : SimpleActivity() {
 
             if (mNotes.size == 1 && note == null) {
                 note = mNotes.first()
-                if (note.isBiometricLockUnavailable(this)) {
+                if (note.shouldBeUnlocked(this)) {
                     updateCurrentNote(note)
                 } else {
                     performSecurityCheck(
@@ -129,7 +129,7 @@ class WidgetConfigureActivity : SimpleActivity() {
         RadioGroupDialog(this, items, mCurrentNoteId.toInt()) {
             val selectedId = it as Int
             val note = mNotes.firstOrNull { it.id!!.toInt() == selectedId } ?: return@RadioGroupDialog
-            if (note.protectionType == PROTECTION_NONE || note.isBiometricLockUnavailable(this)) {
+            if (note.protectionType == PROTECTION_NONE || note.shouldBeUnlocked(this)) {
                 updateCurrentNote(note)
             } else {
                 performSecurityCheck(

--- a/app/src/main/kotlin/com/simplemobiletools/notes/pro/activities/WidgetConfigureActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/notes/pro/activities/WidgetConfigureActivity.kt
@@ -104,16 +104,18 @@ class WidgetConfigureActivity : SimpleActivity() {
 
             if (mNotes.size == 1 && note == null) {
                 note = mNotes.first()
-                performSecurityCheck(
-                    protectionType = note.protectionType,
-                    requiredHash = note.protectionHash,
-                    successCallback = { _, _ -> updateCurrentNote(note) },
-                    failureCallback = { finish() }
-                )
-            } else {
-                if (note != null) {
+                if (note.isBiometricLockUnavailable(this)) {
                     updateCurrentNote(note)
+                } else {
+                    performSecurityCheck(
+                        protectionType = note.protectionType,
+                        requiredHash = note.protectionHash,
+                        successCallback = { _, _ -> updateCurrentNote(note) },
+                        failureCallback = { finish() }
+                    )
                 }
+            } else if (note != null) {
+                updateCurrentNote(note)
             }
         }
     }
@@ -127,7 +129,7 @@ class WidgetConfigureActivity : SimpleActivity() {
         RadioGroupDialog(this, items, mCurrentNoteId.toInt()) {
             val selectedId = it as Int
             val note = mNotes.firstOrNull { it.id!!.toInt() == selectedId } ?: return@RadioGroupDialog
-            if (note.protectionType == PROTECTION_NONE) {
+            if (note.protectionType == PROTECTION_NONE || note.isBiometricLockUnavailable(this)) {
                 updateCurrentNote(note)
             } else {
                 performSecurityCheck(

--- a/app/src/main/kotlin/com/simplemobiletools/notes/pro/fragments/ChecklistFragment.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/notes/pro/fragments/ChecklistFragment.kt
@@ -122,7 +122,9 @@ class ChecklistFragment : NoteFragment(), ChecklistItemsListener {
     }
 
     override fun checkLockState() {
-        if (note == null) return
+        if (note == null) {
+            return
+        }
 
         view.apply {
             checklist_content_holder.beVisibleIf(!note!!.isLocked() || shouldShowLockedContent)

--- a/app/src/main/kotlin/com/simplemobiletools/notes/pro/fragments/ChecklistFragment.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/notes/pro/fragments/ChecklistFragment.kt
@@ -78,11 +78,13 @@ class ChecklistFragment : NoteFragment(), ChecklistItemsListener {
         items.clear()
 
         note.value.split("\n").map { it.trim() }.filter { it.isNotBlank() }.forEachIndexed { index, value ->
-            items.add(ChecklistItem(
-                id = index,
-                title = value,
-                isDone = false
-            ))
+            items.add(
+                ChecklistItem(
+                    id = index,
+                    title = value,
+                    isDone = false
+                )
+            )
         }
 
         saveChecklist()
@@ -120,6 +122,8 @@ class ChecklistFragment : NoteFragment(), ChecklistItemsListener {
     }
 
     override fun checkLockState() {
+        if (note == null) return
+
         view.apply {
             checklist_content_holder.beVisibleIf(!note!!.isLocked() || shouldShowLockedContent)
             checklist_fab.beVisibleIf(!note!!.isLocked() || shouldShowLockedContent)

--- a/app/src/main/kotlin/com/simplemobiletools/notes/pro/fragments/TextFragment.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/notes/pro/fragments/TextFragment.kt
@@ -176,6 +176,8 @@ class TextFragment : NoteFragment() {
     fun removeTextWatcher() = view.text_note_view.removeTextChangedListener(textWatcher)
 
     override fun checkLockState() {
+        if (note == null) return
+
         view.apply {
             notes_counter.beVisibleIf((!note!!.isLocked() || shouldShowLockedContent) && config!!.showWordCount)
             notes_scrollview.beVisibleIf(!note!!.isLocked() || shouldShowLockedContent)
@@ -263,11 +265,13 @@ class TextFragment : NoteFragment() {
             text.removeSpan(span)
         }
 
-        Selection.setSelection(text, if (edit.before == null) {
-            start
-        } else {
-            start + edit.before.length
-        })
+        Selection.setSelection(
+            text, if (edit.before == null) {
+                start
+            } else {
+                start + edit.before.length
+            }
+        )
     }
 
     fun redo() {
@@ -285,11 +289,13 @@ class TextFragment : NoteFragment() {
             text.removeSpan(o)
         }
 
-        Selection.setSelection(text, if (edit.after == null) {
-            start
-        } else {
-            start + edit.after.length
-        })
+        Selection.setSelection(
+            text, if (edit.after == null) {
+                start
+            } else {
+                start + edit.after.length
+            }
+        )
     }
 
     fun isUndoAvailable() = textHistory.position > 0

--- a/app/src/main/kotlin/com/simplemobiletools/notes/pro/fragments/TextFragment.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/notes/pro/fragments/TextFragment.kt
@@ -176,7 +176,9 @@ class TextFragment : NoteFragment() {
     fun removeTextWatcher() = view.text_note_view.removeTextChangedListener(textWatcher)
 
     override fun checkLockState() {
-        if (note == null) return
+        if (note == null) {
+            return
+        }
 
         view.apply {
             notes_counter.beVisibleIf((!note!!.isLocked() || shouldShowLockedContent) && config!!.showWordCount)

--- a/app/src/main/kotlin/com/simplemobiletools/notes/pro/models/Note.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/notes/pro/models/Note.kt
@@ -6,6 +6,8 @@ import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.Index
 import androidx.room.PrimaryKey
+import com.simplemobiletools.commons.extensions.isBiometricIdAvailable
+import com.simplemobiletools.commons.helpers.PROTECTION_FINGERPRINT
 import com.simplemobiletools.commons.helpers.PROTECTION_NONE
 import java.io.File
 
@@ -17,7 +19,8 @@ data class Note(
     @ColumnInfo(name = "type") var type: Int,
     @ColumnInfo(name = "path") var path: String,
     @ColumnInfo(name = "protection_type") var protectionType: Int,
-    @ColumnInfo(name = "protection_hash") var protectionHash: String) {
+    @ColumnInfo(name = "protection_hash") var protectionHash: String
+) {
 
     fun getNoteStoredValue(context: Context): String? {
         return if (path.isNotEmpty()) {
@@ -37,4 +40,8 @@ data class Note(
     }
 
     fun isLocked() = protectionType != PROTECTION_NONE
+
+    fun isBiometricLockUnavailable(context: Context): Boolean {
+        return protectionType == PROTECTION_FINGERPRINT && !context.isBiometricIdAvailable()
+    }
 }

--- a/app/src/main/kotlin/com/simplemobiletools/notes/pro/models/Note.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/notes/pro/models/Note.kt
@@ -41,7 +41,7 @@ data class Note(
 
     fun isLocked() = protectionType != PROTECTION_NONE
 
-    fun isBiometricLockUnavailable(context: Context): Boolean {
+    fun shouldBeUnlocked(context: Context): Boolean {
         return protectionType == PROTECTION_FINGERPRINT && !context.isBiometricIdAvailable()
     }
 }


### PR DESCRIPTION
- Remove note biometric protection if the biometric id is no longer available. This check is done to avoid the user not being able to unlock the note if they remove the biometric id from phone settings.
- Update commons library version.
- Remove `USE_BIOMETRIC` permission. As far as I can tell, it works without explicitly declaring it, because it's declared in the androidx.biometric library itself.