### PR TITLE
Fix error when exporting notes to Google Drive

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/notes/pro/activities/MainActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/notes/pro/activities/MainActivity.kt
@@ -880,7 +880,7 @@ class MainActivity : SimpleActivity() {
 
     private fun exportNoteValueToUri(uri: Uri, content: String, callback: ((success: Boolean) -> Unit)? = null) {
         try {
-            val outputStream = contentResolver.openOutputStream(uri, "wt")
+            val outputStream = contentResolver.openOutputStream(uri, "rwt")
             outputStream!!.bufferedWriter().use { out ->
                 out.write(content)
             }

--- a/app/src/main/kotlin/com/simplemobiletools/notes/pro/activities/MainActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/notes/pro/activities/MainActivity.kt
@@ -750,17 +750,19 @@ class MainActivity : SimpleActivity() {
 
         RadioGroupDialog(this, items) {
             val syncFile = it as Int == EXPORT_FILE_SYNC
-            tryExportNoteValueToFile(exportPath, textToExport, true) {
-                if (syncFile) {
-                    mCurrentNote.path = exportPath
-                    mCurrentNote.value = ""
-                } else {
-                    mCurrentNote.path = ""
-                    mCurrentNote.value = textToExport
-                }
+            tryExportNoteValueToFile(exportPath, textToExport, true) { exportedSuccessfully ->
+                if (exportedSuccessfully) {
+                    if (syncFile) {
+                        mCurrentNote.path = exportPath
+                        mCurrentNote.value = ""
+                    } else {
+                        mCurrentNote.path = ""
+                        mCurrentNote.value = textToExport
+                    }
 
-                getPagerAdapter().updateCurrentNoteData(view_pager.currentItem, mCurrentNote.path, mCurrentNote.value)
-                NotesHelper(this).insertOrUpdateNote(mCurrentNote)
+                    getPagerAdapter().updateCurrentNoteData(view_pager.currentItem, mCurrentNote.path, mCurrentNote.value)
+                    NotesHelper(this).insertOrUpdateNote(mCurrentNote)
+                }
             }
         }
     }
@@ -792,23 +794,26 @@ class MainActivity : SimpleActivity() {
                             toast(String.format(getString(R.string.filename_invalid_characters_placeholder, filename)))
                         } else {
                             val noteStoredValue = note.getNoteStoredValue(this) ?: ""
-                            tryExportNoteValueToFile(file.absolutePath, note.value, false) {
-                                if (syncFile) {
-                                    note.path = file.absolutePath
-                                    note.value = ""
-                                } else {
-                                    note.path = ""
-                                    note.value = noteStoredValue
+                            tryExportNoteValueToFile(file.absolutePath, note.value, false) { exportedSuccessfully ->
+                                if (exportedSuccessfully) {
+                                    if (syncFile) {
+                                        note.path = file.absolutePath
+                                        note.value = ""
+                                    } else {
+                                        note.path = ""
+                                        note.value = noteStoredValue
+                                    }
+
+                                    NotesHelper(this).insertOrUpdateNote(note)
                                 }
 
-                                NotesHelper(this).insertOrUpdateNote(note)
                                 if (mCurrentNote.id == note.id) {
                                     mCurrentNote.value = note.value
                                     mCurrentNote.path = note.path
                                     getPagerAdapter().updateCurrentNoteData(view_pager.currentItem, mCurrentNote.path, mCurrentNote.value)
                                 }
 
-                                if (!it) {
+                                if (!exportedSuccessfully) {
                                     failCount++
                                 }
 


### PR DESCRIPTION
Fixes #444.

- Use "rwt" mode instead of "wt" as the "wt" seems to not work with Google Drive.
- A more general fix to not update note info if export failed.