### PR TITLE
Changed undo/redo visibility behavior (#427)

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/notes/pro/activities/MainActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/notes/pro/activities/MainActivity.kt
@@ -142,6 +142,7 @@ class MainActivity : SimpleActivity() {
                 isEnabled = showUndoButton && mCurrentNote.type == NoteType.TYPE_TEXT.value
                 icon.alpha = if (isEnabled) 255 else 127
             }
+
             findItem(R.id.redo).apply {
                 isVisible = areButtonsVisible
                 isEnabled = showRedoButton && mCurrentNote.type == NoteType.TYPE_TEXT.value

--- a/app/src/main/kotlin/com/simplemobiletools/notes/pro/activities/MainActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/notes/pro/activities/MainActivity.kt
@@ -136,8 +136,17 @@ class MainActivity : SimpleActivity() {
     override fun onCreateOptionsMenu(menu: Menu): Boolean {
         menuInflater.inflate(R.menu.menu, menu)
         menu.apply {
-            findItem(R.id.undo).isVisible = showUndoButton && mCurrentNote.type == NoteType.TYPE_TEXT.value
-            findItem(R.id.redo).isVisible = showRedoButton && mCurrentNote.type == NoteType.TYPE_TEXT.value
+            val areButtonsVisible = (showRedoButton || showUndoButton) && mCurrentNote.type == NoteType.TYPE_TEXT.value
+            findItem(R.id.undo).apply {
+                isVisible = areButtonsVisible
+                isEnabled = showUndoButton && mCurrentNote.type == NoteType.TYPE_TEXT.value
+                icon.alpha = if (isEnabled) 255 else 127
+            }
+            findItem(R.id.redo).apply {
+                isVisible = areButtonsVisible
+                isEnabled = showRedoButton && mCurrentNote.type == NoteType.TYPE_TEXT.value
+                icon.alpha = if (isEnabled) 255 else 127
+            }
         }
 
         updateMenuItemColors(menu)
@@ -505,6 +514,8 @@ class MainActivity : SimpleActivity() {
         NotesHelper(this).insertOrUpdateNote(note) {
             val newNoteId = it
             showSaveButton = false
+            showUndoButton = false
+            showRedoButton = false
             initViewPager(newNoteId)
             updateSelectedNote(newNoteId)
             view_pager.onGlobalLayout {


### PR DESCRIPTION
Hi,

I've changed visibility behavior of undo and redo buttons to avoid problem with jumping undo button as it was described in the issue. You can check on the video below how I've approached it.
Also, while fixing this, I found another bug related to undo/redo buttons - they weren't hiding after creating a new note; I've also fixed it.

**Before:**

https://user-images.githubusercontent.com/85929121/134818281-3c999432-efbf-4242-9f23-d1efc7a8b986.mp4

**After:**

https://user-images.githubusercontent.com/85929121/134818290-e82a72a3-7a74-4249-a0cd-c792bdc181b6.mp4


