### PR TITLE
Added setting custom sorting on move to top/bottom

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/notes/pro/adapters/ChecklistAdapter.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/notes/pro/adapters/ChecklistAdapter.kt
@@ -151,6 +151,7 @@ class ChecklistAdapter(
     }
 
     private fun moveSelectedItemsToTop() {
+        activity.config.sorting = SORT_BY_CUSTOM
         selectedKeys.reversed().forEach { checklistId ->
             val position = items.indexOfFirst { it.id == checklistId }
             val tempItem = items[position]
@@ -163,6 +164,7 @@ class ChecklistAdapter(
     }
 
     private fun moveSelectedItemsToBottom() {
+        activity.config.sorting = SORT_BY_CUSTOM
         selectedKeys.forEach { checklistId ->
             val position = items.indexOfFirst { it.id == checklistId }
             val tempItem = items[position]


### PR DESCRIPTION
Hi,

When setting custom sorting while moving checklist items, there was a missing setting it for move to top/bottom options. I've added it.

**Before:**

https://user-images.githubusercontent.com/85929121/147935465-e7e53779-5918-4612-b756-03b0116fe362.mp4

**After:**

https://user-images.githubusercontent.com/85929121/147935474-dafa0064-4e3f-49df-bd24-446301346fcc.mp4
