### PR TITLE
Added shortcuts for new text note and checklist (#495)

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/notes/pro/helpers/Constants.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/notes/pro/helpers/Constants.kt
@@ -11,6 +11,10 @@ const val CUSTOMIZED_WIDGET_NOTE_ID = "customized_widget_note_id"
 const val CUSTOMIZED_WIDGET_BG_COLOR = "customized_widget_bg_color"
 const val CUSTOMIZED_WIDGET_TEXT_COLOR = "customized_widget_text_color"
 const val CUSTOMIZED_WIDGET_SHOW_TITLE = "customized_widget_show_title"
+const val SHORTCUT_NEW_TEXT_NOTE = "shortcut_new_text_note"
+const val SHORTCUT_NEW_CHECKLIST = "shortcut_new_checklist"
+const val NEW_TEXT_NOTE = "new_text_note"
+const val NEW_CHECKLIST = "new_checklist"
 val DEFAULT_WIDGET_TEXT_COLOR = Color.parseColor("#FFF57C00")
 
 // shared preferences

--- a/app/src/main/res/drawable/shortcut_check.xml
+++ b/app/src/main/res/drawable/shortcut_check.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:id="@+id/shortcut_plus_background">
+        <shape android:shape="oval">
+            <solid android:color="@color/color_primary"/>
+        </shape>
+    </item>
+    <item android:bottom="@dimen/medium_margin" android:drawable="@drawable/ic_check_vector" android:left="@dimen/medium_margin" android:right="@dimen/medium_margin" android:top="@dimen/medium_margin"/>
+</layer-list>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -27,6 +27,8 @@
     <string name="note_content_locked">محتوى الملاحظات مؤمن.</string>
     <string name="show_content">إظهار المحتوى</string>
     <string name="locking_warning">تحذير: إذا نسيت كلمة مرور الملاحظات، فلن تتمكن من استعادتها أو الوصول إلى محتوى الملاحظات بعد الآن.</string>
+    <string name="new_text_note">New text note</string>
+    <string name="new_checklist">New checklist</string>
     <!-- File notes -->
     <string name="open_file">فتح ملف</string>
     <string name="export_as_file">تصدير كملف</string>

--- a/app/src/main/res/values-az/strings.xml
+++ b/app/src/main/res/values-az/strings.xml
@@ -25,6 +25,8 @@
     <string name="note_content_locked">The notes\' content is locked.</string>
     <string name="show_content">Show content</string>
     <string name="locking_warning">WARNING: If you forget the notes\' password, you won\'t be able to recover it or access the notes\' content anymore.</string>
+    <string name="new_text_note">New text note</string>
+    <string name="new_checklist">New checklist</string>
 
     <!-- File notes -->
     <string name="open_file">Faylı Aç</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -25,6 +25,8 @@
     <string name="note_content_locked">The notes\' content is locked.</string>
     <string name="show_content">Show content</string>
     <string name="locking_warning">WARNING: If you forget the notes\' password, you won\'t be able to recover it or access the notes\' content anymore.</string>
+    <string name="new_text_note">New text note</string>
+    <string name="new_checklist">New checklist</string>
 
     <!-- File notes -->
     <string name="open_file">Otevřít soubor</string>

--- a/app/src/main/res/values-cy/strings.xml
+++ b/app/src/main/res/values-cy/strings.xml
@@ -25,6 +25,8 @@
     <string name="note_content_locked">The notes\' content is locked.</string>
     <string name="show_content">Show content</string>
     <string name="locking_warning">WARNING: If you forget the notes\' password, you won\'t be able to recover it or access the notes\' content anymore.</string>
+    <string name="new_text_note">New text note</string>
+    <string name="new_checklist">New checklist</string>
 
     <!-- File notes -->
     <string name="open_file">Agor ffeil</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -25,6 +25,8 @@
     <string name="note_content_locked">The notes\' content is locked.</string>
     <string name="show_content">Show content</string>
     <string name="locking_warning">WARNING: If you forget the notes\' password, you won\'t be able to recover it or access the notes\' content anymore.</string>
+    <string name="new_text_note">New text note</string>
+    <string name="new_checklist">New checklist</string>
 
     <!-- File notes -->
     <string name="open_file">Åbn fil …</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -26,6 +26,8 @@
     <string name="note_content_locked">Der Inhalt der Notizen ist gesperrt.</string>
     <string name="show_content">Inhalt anzeigen</string>
     <string name="locking_warning">ACHTUNG: Wenn Sie das Kennwort für die Notizen vergessen, können Sie es nicht mehr wiederherstellen oder auf den Inhalt der Notizen zugreifen.</string>
+    <string name="new_text_note">New text note</string>
+    <string name="new_checklist">New checklist</string>
     <!-- File notes -->
     <string name="open_file">Datei öffnen</string>
     <string name="export_as_file">Als Datei exportieren</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -25,6 +25,8 @@
     <string name="note_content_locked">Το περιεχόμενο των Σημειώσεων είναι κλειδωμένο.</string>
     <string name="show_content">Εμφάνιση περιεχομένου</string>
     <string name="locking_warning">ΠΡΟΣΟΧΗ: Εάν ξεχάσετε τον κωδικό των σημειώσεων, δεν θα μπορείτε πλέον να τον ανακτήσετε ή να αποκτήσετε πρόσβαση στο περιεχόμενο τους.</string>
+    <string name="new_text_note">New text note</string>
+    <string name="new_checklist">New checklist</string>
 
     <!-- File notes -->
     <string name="open_file">Άνοιγμα αρχείου</string>

--- a/app/src/main/res/values-eo/strings.xml
+++ b/app/src/main/res/values-eo/strings.xml
@@ -26,6 +26,8 @@
     <string name="note_content_locked">The notes\' content is locked.</string>
     <string name="show_content">Montri enhavon</string>
     <string name="locking_warning">WARNING: If you forget the notes\' password, you won\'t be able to recover it or access the notes\' content anymore.</string>
+    <string name="new_text_note">New text note</string>
+    <string name="new_checklist">New checklist</string>
     <!-- File notes -->
     <string name="open_file">Malfermi dosieron</string>
     <string name="export_as_file">Export as file</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -25,6 +25,8 @@
     <string name="note_content_locked">El contenido de esta nota está bloqueado.</string>
     <string name="show_content">Mostrar contenido</string>
     <string name="locking_warning">ADVERTENCIA: Si olvidas la contraseña de esta nota, ya no podrás recuperar su contenido.</string>
+    <string name="new_text_note">New text note</string>
+    <string name="new_checklist">New checklist</string>
 
     <!-- File notes -->
     <string name="open_file">Abrir archivo</string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -27,6 +27,8 @@
     <string name="note_content_locked">The notes\' content is locked.</string>
     <string name="show_content">Show content</string>
     <string name="locking_warning">WARNING: If you forget the notes\' password, you won\'t be able to recover it or access the notes\' content anymore.</string>
+    <string name="new_text_note">New text note</string>
+    <string name="new_checklist">New checklist</string>
 
     <!-- File notes -->
     <string name="open_file">Ava fail</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -25,6 +25,8 @@
     <string name="note_content_locked">محتویات یادداشت، قفل است</string>
     <string name="show_content">نمایش محتویات</string>
     <string name="locking_warning">هشدار: اگر گذرواژهٔ یادداشت را فراموش کنید، دیگر قادر به بازیابی آن یا دسترسی به محتویات یادداشت نیستید.</string>
+    <string name="new_text_note">New text note</string>
+    <string name="new_checklist">New checklist</string>
 
     <!-- File notes -->
     <string name="open_file">بازکردن پرونده</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -26,6 +26,8 @@
     <string name="note_content_locked">Muistiinpanon sisältö on lukittu.</string>
     <string name="show_content">Näytä sisältö</string>
     <string name="locking_warning">VAROITUS: Jos unohdat muistiinpanon salasanan, sitä ei ole mahdollista palauttaa etkä pääse enää käsiksi muistiinpanoon.</string>
+    <string name="new_text_note">New text note</string>
+    <string name="new_checklist">New checklist</string>
     <!-- File notes -->
     <string name="open_file">Avaa tiedosto</string>
     <string name="export_as_file">Vie tiedostona</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -26,6 +26,8 @@
     <string name="note_content_locked">Le contenu des notes est verrouillé.</string>
     <string name="show_content">Montrer le contenu</string>
     <string name="locking_warning">AVERTISSEMENT : Si vous oubliez le mot de passe des notes, vous ne pourrez plus le récupérer ni accéder au contenu des notes.</string>
+    <string name="new_text_note">New text note</string>
+    <string name="new_checklist">New checklist</string>
     <!-- File notes -->
     <string name="open_file">Ouvrir le fichier</string>
     <string name="export_as_file">Exporter dans un fichier</string>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -25,6 +25,8 @@
     <string name="note_content_locked">The notes\' content is locked.</string>
     <string name="show_content">Show content</string>
     <string name="locking_warning">WARNING: If you forget the notes\' password, you won\'t be able to recover it or access the notes\' content anymore.</string>
+    <string name="new_text_note">New text note</string>
+    <string name="new_checklist">New checklist</string>
 
     <!-- File notes -->
     <string name="open_file">Abrir ficheiro</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -25,6 +25,8 @@
     <string name="note_content_locked">The notes\' content is locked.</string>
     <string name="show_content">Show content</string>
     <string name="locking_warning">WARNING: If you forget the notes\' password, you won\'t be able to recover it or access the notes\' content anymore.</string>
+    <string name="new_text_note">New text note</string>
+    <string name="new_checklist">New checklist</string>
 
     <!-- File notes -->
     <string name="open_file">Otvori datoteku</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -27,6 +27,8 @@
     <string name="note_content_locked">A jegyzet tartalma zárolva van.</string>
     <string name="show_content">Show content</string>
     <string name="locking_warning">FIGYELMEZTETÉS: Ha elfelejti a jegyzetek jelszavát, akkor többé nem fogja tudni helyreállítani vagy elérni a jegyzetek tartalmát.</string>
+    <string name="new_text_note">New text note</string>
+    <string name="new_checklist">New checklist</string>
     <!-- File notes -->
     <string name="open_file">Fájl megnyitása</string>
     <string name="export_as_file">Exportálás fájlba</string>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -25,6 +25,8 @@
     <string name="note_content_locked">The notes\' content is locked.</string>
     <string name="show_content">Show content</string>
     <string name="locking_warning">WARNING: If you forget the notes\' password, you won\'t be able to recover it or access the notes\' content anymore.</string>
+    <string name="new_text_note">New text note</string>
+    <string name="new_checklist">New checklist</string>
 
     <!-- File notes -->
     <string name="open_file">Buka berkas</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -26,6 +26,8 @@
     <string name="note_content_locked">Il contenuto delle note è bloccato.</string>
     <string name="show_content">Mostra il contenuto</string>
     <string name="locking_warning">ATTENZIONE: Se dimentichi la password delle note, non sarai più in grado di recuperarla o di accedere al contenuto delle note.</string>
+    <string name="new_text_note">New text note</string>
+    <string name="new_checklist">New checklist</string>
     <!-- File notes -->
     <string name="open_file">Apri file</string>
     <string name="export_as_file">Esporta come file</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -25,6 +25,8 @@
     <string name="note_content_locked">The notes\' content is locked.</string>
     <string name="show_content">Show content</string>
     <string name="locking_warning">WARNING: If you forget the notes\' password, you won\'t be able to recover it or access the notes\' content anymore.</string>
+    <string name="new_text_note">New text note</string>
+    <string name="new_checklist">New checklist</string>
 
     <!-- File notes -->
     <string name="open_file">ファイルを開く</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -25,6 +25,8 @@
     <string name="note_content_locked">The notes\' content is locked.</string>
     <string name="show_content">Show content</string>
     <string name="locking_warning">WARNING: If you forget the notes\' password, you won\'t be able to recover it or access the notes\' content anymore.</string>
+    <string name="new_text_note">New text note</string>
+    <string name="new_checklist">New checklist</string>
 
     <!-- File notes -->
     <string name="open_file">Atverti bylą</string>

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -26,6 +26,8 @@
     <string name="note_content_locked">Notatinnholdet er låst.</string>
     <string name="show_content">Vis innhold</string>
     <string name="locking_warning">Advarsel: Hvis du glemmer notatpassordet vil du ikke kunne gjenopprette det eller innholdet.</string>
+    <string name="new_text_note">New text note</string>
+    <string name="new_checklist">New checklist</string>
     <!-- File notes -->    
     <string name="open_file">Åpne fil</string>
     <string name="export_as_file">Eksporter som fil</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -25,6 +25,8 @@
     <string name="note_content_locked">De inhoud van deze notitie is vergrendeld.</string>
     <string name="show_content">Inhoud weergeven</string>
     <string name="locking_warning">WAARSCHUWING: Zonder het wachtwoord kan de inhoud van de notitie niet meer worden hersteld.</string>
+    <string name="new_text_note">New text note</string>
+    <string name="new_checklist">New checklist</string>
 
     <!-- File notes -->
     <string name="open_file">Bestand openen</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -26,6 +26,8 @@
     <string name="note_content_locked">Treść notatki jest zablokowana.</string>
     <string name="show_content">Pokaż zawartość</string>
     <string name="locking_warning">OSTRZEŻENIE: Jeśli zapomnisz hasła do notatki, nie będziesz już mógł/mogła jej odzyskać ani uzyskać dostępu do treści notatki.</string>
+    <string name="new_text_note">Nowa notatka tekstowa</string>
+    <string name="new_checklist">Nowa lista kontrolna</string>
     <!-- File notes -->
     <string name="open_file">Otwórz plik</string>
     <string name="export_as_file">Eksportuj jako plik</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -25,6 +25,8 @@
     <string name="note_content_locked">O conteúdo da anotação está bloqueado.</string>
     <string name="show_content">Mostrar conteúdo</string>
     <string name="locking_warning">AVISO: Caso você esqueça a senha, não conseguirá acessar o conteúdo.</string>
+    <string name="new_text_note">New text note</string>
+    <string name="new_checklist">New checklist</string>
 
     <!-- File notes -->
     <string name="open_file">Abrir arquivo</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -25,6 +25,8 @@
     <string name="note_content_locked">O conteúdo da nota está bloqueado.</string>
     <string name="show_content">Mostrar conteúdo</string>
     <string name="locking_warning">AVISO: se esquecer a palavra-passe, não conseguirá aceder à nota nem recuperar o seu conteúdo.</string>
+    <string name="new_text_note">New text note</string>
+    <string name="new_checklist">New checklist</string>
 
     <!-- File notes -->
     <string name="open_file">Abrir ficheiro</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -26,6 +26,8 @@
     <string name="note_content_locked">Содержимое заметки заблокировано.</string>
     <string name="show_content">Показывать содержание</string>
     <string name="locking_warning">ПРЕДУПРЕЖДЕНИЕ: если вы забудете пароль, то не сможете восстановить его или получить доступ к содержимому заметок.</string>
+    <string name="new_text_note">New text note</string>
+    <string name="new_checklist">New checklist</string>
     <!-- File notes -->
     <string name="open_file">Открыть файл</string>
     <string name="export_as_file">Экспортировать в файл</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -25,8 +25,8 @@
     <string name="note_content_locked">Obsah poznámky je uzamknutý.</string>
     <string name="show_content">Zobraziť obsah</string>
     <string name="locking_warning">UPOZORNENIE: Ak zabudnete heslo poznámky, nebudete ho môcť obnoviť, ani sa už dostať k obsahu poznámky.</string>
-    <string name="new_text_note">New text note</string>
-    <string name="new_checklist">New checklist</string>
+    <string name="new_text_note">Nová textová poznámka</string>
+    <string name="new_checklist">Nový zoznam položiek</string>
 
     <!-- File notes -->
     <string name="open_file">Otvoriť súbor</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -25,6 +25,8 @@
     <string name="note_content_locked">Obsah poznámky je uzamknutý.</string>
     <string name="show_content">Zobraziť obsah</string>
     <string name="locking_warning">UPOZORNENIE: Ak zabudnete heslo poznámky, nebudete ho môcť obnoviť, ani sa už dostať k obsahu poznámky.</string>
+    <string name="new_text_note">New text note</string>
+    <string name="new_checklist">New checklist</string>
 
     <!-- File notes -->
     <string name="open_file">Otvoriť súbor</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -25,6 +25,8 @@
     <string name="note_content_locked">The notes\' content is locked.</string>
     <string name="show_content">Show content</string>
     <string name="locking_warning">WARNING: If you forget the notes\' password, you won\'t be able to recover it or access the notes\' content anymore.</string>
+    <string name="new_text_note">New text note</string>
+    <string name="new_checklist">New checklist</string>
 
     <!-- File notes -->
     <string name="open_file">Öppna fil</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -26,6 +26,8 @@
     <string name="note_content_locked">Notların içeriği kilitlendi.</string>
     <string name="show_content">İçeriği göster</string>
     <string name="locking_warning">UYARI: Notların parolasını unutursanız, onu kurtaramaz veya notların içeriğine artık erişemezsiniz.</string>
+    <string name="new_text_note">New text note</string>
+    <string name="new_checklist">New checklist</string>
     <!-- File notes -->
     <string name="open_file">Dosya aç</string>
     <string name="export_as_file">Dosya olarak aktar</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -25,6 +25,8 @@
     <string name="note_content_locked">Нотатку заблоковано.</string>
     <string name="show_content">Показати нотатку</string>
     <string name="locking_warning">УВАГА: Якщо ви забудете пароль доступу до нотатки, ви більше не зможете його відновити або прочитати нотатку.</string>
+    <string name="new_text_note">New text note</string>
+    <string name="new_checklist">New checklist</string>
 
     <!-- File notes -->
     <string name="open_file">Відкрити файл</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -26,6 +26,8 @@
     <string name="note_content_locked">笔记的内容被锁定。</string>
     <string name="show_content">显示内容</string>
     <string name="locking_warning">警告：如果您忘记了笔记的密码，您将无法恢复或访问笔记的内容。</string>
+    <string name="new_text_note">New text note</string>
+    <string name="new_checklist">New checklist</string>
     <!-- File notes -->
     <string name="open_file">打开文件</string>
     <string name="export_as_file">以文件的形式导出</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -25,6 +25,8 @@
     <string name="note_content_locked">The notes\' content is locked.</string>
     <string name="show_content">Show content</string>
     <string name="locking_warning">WARNING: If you forget the notes\' password, you won\'t be able to recover it or access the notes\' content anymore.</string>
+    <string name="new_text_note">New text note</string>
+    <string name="new_checklist">New checklist</string>
 
     <!-- File notes -->
     <string name="open_file">打開檔案</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -25,6 +25,8 @@
     <string name="note_content_locked">The notes\' content is locked.</string>
     <string name="show_content">Show content</string>
     <string name="locking_warning">WARNING: If you forget the notes\' password, you won\'t be able to recover it or access the notes\' content anymore.</string>
+    <string name="new_text_note">New text note</string>
+    <string name="new_checklist">New checklist</string>
 
     <!-- File notes -->
     <string name="open_file">Open file</string>


### PR DESCRIPTION
Hi,

I've added shortcuts for creating a new text note and a new checklist. Each new note has a prefilled title with the current date. Closes #495.

https://user-images.githubusercontent.com/85929121/150641204-c122b2b2-b0b6-4ba3-9c64-dbf3924127c9.mp4
