### PR TITLE
Added padding for checklist to avoid hiding the last item (#443)

### DIFF
--- a/app/src/main/res/layout/fragment_checklist.xml
+++ b/app/src/main/res/layout/fragment_checklist.xml
@@ -60,6 +60,7 @@
                 android:clipToPadding="false"
                 android:overScrollMode="never"
                 android:visibility="gone"
+                android:paddingBottom="@dimen/secondary_fab_bottom_margin"
                 app:layoutManager="com.simplemobiletools.commons.views.MyLinearLayoutManager" />
 
             <com.simplemobiletools.commons.views.MyTextView

--- a/app/src/main/res/layout/fragment_checklist.xml
+++ b/app/src/main/res/layout/fragment_checklist.xml
@@ -59,8 +59,8 @@
                 android:layout_height="match_parent"
                 android:clipToPadding="false"
                 android:overScrollMode="never"
-                android:visibility="gone"
                 android:paddingBottom="@dimen/secondary_fab_bottom_margin"
+                android:visibility="gone"
                 app:layoutManager="com.simplemobiletools.commons.views.MyLinearLayoutManager" />
 
             <com.simplemobiletools.commons.views.MyTextView


### PR DESCRIPTION
Hi,

There's my proposition how to solve the issue that action button hides the last item check. 
- Closes #443. 
- I've added a padding to the recycler view, so the user can scroll a bit more to the top and the last item is fully visible with a bit of space underneath.
- It was the easiest to do and doesn't change too much how the app looks.

**Before:**

https://user-images.githubusercontent.com/85929121/154661150-b34aef59-761d-4c4b-b0b6-e41bab18a3d3.mp4

**After:**

https://user-images.githubusercontent.com/85929121/154661166-4d1a051b-f282-43f7-bb48-f11b393e7dc8.mp4
