### PR TITLE
Fixed unnecessary note creating on app resume

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/notes/pro/activities/MainActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/notes/pro/activities/MainActivity.kt
@@ -338,20 +338,25 @@ class MainActivity : SimpleActivity() {
 
             if (action == Intent.ACTION_VIEW) {
                 val realPath = intent.getStringExtra(REAL_FILE_PATH)
-                if (realPath != null && hasPermission(PERMISSION_READ_STORAGE)) {
-                    val file = File(realPath)
-                    handleUri(Uri.fromFile(file))
-                } else if (intent.getBooleanExtra(NEW_TEXT_NOTE, false)) {
-                    val newTextNote = Note(null, getCurrentFormattedDateTime(), "", NoteType.TYPE_TEXT.value, "", PROTECTION_NONE, "")
-                    addNewNote(newTextNote)
-                } else if (intent.getBooleanExtra(NEW_CHECKLIST, false)) {
-                    val newChecklist = Note(null, getCurrentFormattedDateTime(), "", NoteType.TYPE_CHECKLIST.value, "", PROTECTION_NONE, "")
-                    addNewNote(newChecklist)
-                } else {
-                    handleUri(data!!)
+                val isFromHistory = intent.flags and Intent.FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY != 0
+                if (!isFromHistory) {
+                    if (realPath != null && hasPermission(PERMISSION_READ_STORAGE)) {
+                        val file = File(realPath)
+                        handleUri(Uri.fromFile(file))
+                    } else if (intent.getBooleanExtra(NEW_TEXT_NOTE, false)) {
+                        val newTextNote = Note(null, getCurrentFormattedDateTime(), "", NoteType.TYPE_TEXT.value, "", PROTECTION_NONE, "")
+                        addNewNote(newTextNote)
+                    } else if (intent.getBooleanExtra(NEW_CHECKLIST, false)) {
+                        val newChecklist = Note(null, getCurrentFormattedDateTime(), "", NoteType.TYPE_CHECKLIST.value, "", PROTECTION_NONE, "")
+                        addNewNote(newChecklist)
+                    } else {
+                        handleUri(data!!)
+                    }
                 }
                 intent.removeCategory(Intent.CATEGORY_DEFAULT)
                 intent.action = null
+                intent.removeExtra(NEW_CHECKLIST)
+                intent.removeExtra(NEW_TEXT_NOTE)
             }
         }
     }


### PR DESCRIPTION
Hi,

I've found a bug related to creating notes from shortcuts. After creating such note, if user exit the app by using back button, reverting it back from recents screen was triggering creating note once again. The issue was that intent was being reverted from history, so to fix it, I've added checking intent's flags if it's not from history. Also, to be sure that everything will work fine, I've added removing extras from intent after using them.

**Before:**

https://user-images.githubusercontent.com/85929121/155188634-75156af9-b36c-42b0-952d-a029d1165bc8.mp4

**After:**

https://user-images.githubusercontent.com/85929121/155188718-42217ed9-89ac-415a-a561-3776f2b12548.mp4

