### PR TITLE
Added synchronization to checklist export and import

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/notes/pro/activities/MainActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/notes/pro/activities/MainActivity.kt
@@ -643,7 +643,11 @@ class MainActivity : SimpleActivity() {
                     if (checklistItems != null) {
                         val title = it.absolutePath.getFilenameFromPath().substringBeforeLast('.')
                         val note = Note(null, title, fileText, NoteType.TYPE_CHECKLIST.value, "", PROTECTION_NONE, "")
-                        displayNewNoteDialog(note.value, title = title, setChecklistAsDefault = true)
+                        runOnUiThread {
+                            OpenFileDialog(this, it.path) {
+                                displayNewNoteDialog(note.value, title = it.title, it.path, setChecklistAsDefault = true)
+                            }
+                        }
                     } else {
                         runOnUiThread {
                             OpenFileDialog(this, it.path) {
@@ -740,11 +744,9 @@ class MainActivity : SimpleActivity() {
             }
         }
 
-        if (checklistItems != null) {
-            val note = Note(null, noteTitle, content, NoteType.TYPE_CHECKLIST.value, "", PROTECTION_NONE, "")
-            displayNewNoteDialog(note.value, title = noteTitle, setChecklistAsDefault = true)
-        } else if (!canSyncNoteWithFile) {
-            val note = Note(null, noteTitle, content, NoteType.TYPE_TEXT.value, "", PROTECTION_NONE, "")
+        val noteType = if (checklistItems != null) NoteType.TYPE_CHECKLIST.value else NoteType.TYPE_TEXT.value
+        if (!canSyncNoteWithFile) {
+            val note = Note(null, noteTitle, content, noteType, "", PROTECTION_NONE, "")
             displayNewNoteDialog(note.value, title = noteTitle, "")
         } else {
             val items = arrayListOf(
@@ -755,7 +757,7 @@ class MainActivity : SimpleActivity() {
             RadioGroupDialog(this, items) {
                 val syncFile = it as Int == IMPORT_FILE_SYNC
                 val path = if (syncFile) uri.toString() else ""
-                val note = Note(null, noteTitle, content, NoteType.TYPE_TEXT.value, "", PROTECTION_NONE, "")
+                val note = Note(null, noteTitle, content, noteType, "", PROTECTION_NONE, "")
                 displayNewNoteDialog(note.value, title = noteTitle, path)
             }
         }

--- a/app/src/main/kotlin/com/simplemobiletools/notes/pro/adapters/NotesPagerAdapter.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/notes/pro/adapters/NotesPagerAdapter.kt
@@ -39,7 +39,7 @@ class NotesPagerAdapter(fm: FragmentManager, val notes: List<Note>, val activity
     override fun getPageTitle(position: Int) = notes[position].title
 
     fun updateCurrentNoteData(position: Int, path: String, value: String) {
-        (fragments[position] as? TextFragment)?.apply {
+        (fragments[position])?.apply {
             updateNotePath(path)
             updateNoteValue(value)
         }

--- a/app/src/main/kotlin/com/simplemobiletools/notes/pro/fragments/NoteFragment.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/notes/pro/fragments/NoteFragment.kt
@@ -8,8 +8,10 @@ import com.simplemobiletools.commons.extensions.beVisibleIf
 import com.simplemobiletools.commons.extensions.getAdjustedPrimaryColor
 import com.simplemobiletools.commons.extensions.performSecurityCheck
 import com.simplemobiletools.commons.helpers.PROTECTION_NONE
+import com.simplemobiletools.notes.pro.activities.MainActivity
 import com.simplemobiletools.notes.pro.extensions.config
 import com.simplemobiletools.notes.pro.extensions.getPercentageFontSize
+import com.simplemobiletools.notes.pro.helpers.NotesHelper
 import com.simplemobiletools.notes.pro.models.Note
 import kotlinx.android.synthetic.main.fragment_checklist.view.*
 
@@ -33,6 +35,19 @@ abstract class NoteFragment : Fragment() {
         }
     }
 
+    protected fun saveNoteValue(note: Note, content: String?) {
+        if (note.path.isEmpty()) {
+            NotesHelper(activity!!).insertOrUpdateNote(note) {
+                (activity as? MainActivity)?.noteSavedSuccessfully(note.title)
+            }
+        } else {
+            if (content != null) {
+                val displaySuccess = activity?.config?.displaySuccess ?: false
+                (activity as? MainActivity)?.tryExportNoteValueToFile(note.path, content, displaySuccess)
+            }
+        }
+    }
+
     fun handleUnlocking(callback: (() -> Unit)? = null) {
         if (callback != null && (note!!.protectionType == PROTECTION_NONE || shouldShowLockedContent)) {
             callback()
@@ -48,6 +63,14 @@ abstract class NoteFragment : Fragment() {
                 callback?.invoke()
             }
         )
+    }
+
+    fun updateNoteValue(value: String) {
+        note?.value = value
+    }
+
+    fun updateNotePath(path: String) {
+        note?.path = path
     }
 
     abstract fun checkLockState()

--- a/app/src/main/kotlin/com/simplemobiletools/notes/pro/fragments/TextFragment.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/notes/pro/fragments/TextFragment.kt
@@ -23,7 +23,6 @@ import com.simplemobiletools.notes.pro.extensions.updateWidgets
 import com.simplemobiletools.notes.pro.helpers.MyMovementMethod
 import com.simplemobiletools.notes.pro.helpers.NOTE_ID
 import com.simplemobiletools.notes.pro.helpers.NotesHelper
-import com.simplemobiletools.notes.pro.models.Note
 import com.simplemobiletools.notes.pro.models.TextHistory
 import com.simplemobiletools.notes.pro.models.TextHistoryItem
 import kotlinx.android.synthetic.main.fragment_text.view.*
@@ -187,14 +186,6 @@ class TextFragment : NoteFragment() {
         }
     }
 
-    fun updateNoteValue(value: String) {
-        note?.value = value
-    }
-
-    fun updateNotePath(path: String) {
-        note?.path = path
-    }
-
     fun getNotesView() = view.text_note_view
 
     fun saveText(force: Boolean) {
@@ -214,7 +205,7 @@ class TextFragment : NoteFragment() {
         val oldText = note!!.getNoteStoredValue(context!!)
         if (newText != null && (newText != oldText || force)) {
             note!!.value = newText
-            saveNoteValue(note!!)
+            saveNoteValue(note!!, newText)
             context!!.updateWidgets()
         }
     }
@@ -223,20 +214,6 @@ class TextFragment : NoteFragment() {
 
     fun focusEditText() {
         view.text_note_view.requestFocus()
-    }
-
-    private fun saveNoteValue(note: Note) {
-        if (note.path.isEmpty()) {
-            NotesHelper(activity!!).insertOrUpdateNote(note) {
-                (activity as? MainActivity)?.noteSavedSuccessfully(note.title)
-            }
-        } else {
-            val currentText = getCurrentNoteViewText()
-            if (currentText != null) {
-                val displaySuccess = activity?.config?.displaySuccess ?: false
-                (activity as? MainActivity)?.tryExportNoteValueToFile(note.path, currentText, displaySuccess)
-            }
-        }
     }
 
     fun getCurrentNoteViewText() = view.text_note_view?.text?.toString()


### PR DESCRIPTION
Hi,

While working on all notes export/import, I've found out, that synchronization of checklists wasn't working at all, despite that the option was visible. I've added it fully, both on export and import.

Details:
- I'm reusing save logic for notes in checklists (moved it to more common place).
- Moved reading checklists from directly reading value from DB to helper that also reads from file.
- Also moved code related to note updates to NoteFragment, not to be invoked just for text notes.
- Added the same null-checks before saving checklist as there are for notes.

https://user-images.githubusercontent.com/85929121/155588847-bd365d25-ba07-4909-a18e-992b79a72df8.mp4
