### PR TITLE
Fixed wrong title in export toast

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/notes/pro/activities/MainActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/notes/pro/activities/MainActivity.kt
@@ -844,7 +844,7 @@ class MainActivity : SimpleActivity() {
             } else if (mCurrentNote.type == NoteType.TYPE_TEXT.value) {
                 showExportFilePickUpdateDialog(it, textToExport)
             } else {
-                tryExportNoteValueToFile(it, textToExport, true)
+                tryExportNoteValueToFile(it, mCurrentNote.title, textToExport, true)
             }
         }
     }
@@ -857,7 +857,7 @@ class MainActivity : SimpleActivity() {
 
         RadioGroupDialog(this, items) {
             val syncFile = it as Int == EXPORT_FILE_SYNC
-            tryExportNoteValueToFile(exportPath, textToExport, true) { exportedSuccessfully ->
+            tryExportNoteValueToFile(exportPath, mCurrentNote.title, textToExport, true) { exportedSuccessfully ->
                 if (exportedSuccessfully) {
                     if (syncFile) {
                         mCurrentNote.path = exportPath
@@ -901,7 +901,7 @@ class MainActivity : SimpleActivity() {
                             toast(String.format(getString(R.string.filename_invalid_characters_placeholder, filename)))
                         } else {
                             val noteStoredValue = note.getNoteStoredValue(this) ?: ""
-                            tryExportNoteValueToFile(file.absolutePath, note.value, false) { exportedSuccessfully ->
+                            tryExportNoteValueToFile(file.absolutePath, mCurrentNote.title, note.value, false) { exportedSuccessfully ->
                                 if (exportedSuccessfully) {
                                     if (syncFile) {
                                         note.path = file.absolutePath
@@ -935,9 +935,9 @@ class MainActivity : SimpleActivity() {
         }
     }
 
-    fun tryExportNoteValueToFile(path: String, content: String, showSuccessToasts: Boolean, callback: ((success: Boolean) -> Unit)? = null) {
+    fun tryExportNoteValueToFile(path: String, title: String, content: String, showSuccessToasts: Boolean, callback: ((success: Boolean) -> Unit)? = null) {
         if (path.startsWith("content://")) {
-            exportNoteValueToUri(Uri.parse(path), content, callback)
+            exportNoteValueToUri(Uri.parse(path), title, content, showSuccessToasts, callback)
         } else {
             handlePermission(PERMISSION_WRITE_STORAGE) {
                 if (it) {
@@ -990,13 +990,15 @@ class MainActivity : SimpleActivity() {
         }
     }
 
-    private fun exportNoteValueToUri(uri: Uri, content: String, callback: ((success: Boolean) -> Unit)? = null) {
+    private fun exportNoteValueToUri(uri: Uri, title: String, content: String, showSuccessToasts: Boolean, callback: ((success: Boolean) -> Unit)? = null) {
         try {
             val outputStream = contentResolver.openOutputStream(uri, "rwt")
             outputStream!!.bufferedWriter().use { out ->
                 out.write(content)
             }
-            noteExportedSuccessfully(mCurrentNote.title)
+            if (showSuccessToasts) {
+                noteExportedSuccessfully(title)
+            }
             callback?.invoke(true)
         } catch (e: Exception) {
             showErrorToast(e)

--- a/app/src/main/kotlin/com/simplemobiletools/notes/pro/fragments/NoteFragment.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/notes/pro/fragments/NoteFragment.kt
@@ -43,7 +43,7 @@ abstract class NoteFragment : Fragment() {
         } else {
             if (content != null) {
                 val displaySuccess = activity?.config?.displaySuccess ?: false
-                (activity as? MainActivity)?.tryExportNoteValueToFile(note.path, content, displaySuccess)
+                (activity as? MainActivity)?.tryExportNoteValueToFile(note.path, note.title, content, displaySuccess)
             }
         }
     }


### PR DESCRIPTION
Hi,

I've noticed that toast about successful export wasn't always showing the proper note title. Here's a fix for this. Also, I've noticed that in one case toast was displayed despite the option to not show it, so I've added a condition.

**Before:**

https://user-images.githubusercontent.com/85929121/157256189-3e71977e-e58e-473b-bb58-6af1683288ac.mp4

**After:**

https://user-images.githubusercontent.com/85929121/157256358-309a49f9-5b7c-4bc0-b90d-ecf3e8bbadf8.mp4