### PR TITLE
Fixed missing content of checklist widget

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/notes/pro/adapters/WidgetAdapter.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/notes/pro/adapters/WidgetAdapter.kt
@@ -125,7 +125,7 @@ class WidgetAdapter(val context: Context, val intent: Intent) : RemoteViewsServi
         note = context.notesDB.getNoteWithId(noteId)
         if (note?.type == NoteType.TYPE_CHECKLIST.value) {
             val checklistItemType = object : TypeToken<List<ChecklistItem>>() {}.type
-            checklistItems = Gson().fromJson<ArrayList<ChecklistItem>>(note!!.value, checklistItemType) ?: ArrayList(1)
+            checklistItems = Gson().fromJson<ArrayList<ChecklistItem>>(note!!.getNoteStoredValue(context), checklistItemType) ?: ArrayList(1)
 
             // checklist title can be null only because of the glitch in upgrade to 6.6.0, remove this check in the future
             checklistItems = checklistItems.filter { it.title != null }.toMutableList() as ArrayList<ChecklistItem>


### PR DESCRIPTION
Hi,

Here's a fix for a bug, that checklist widget content was missing when checklist was synchronized. It was still using value taken directly from the DB instead of a helper function - I've changed it.