### PR TITLE
Allow exporting locked notes

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/notes/pro/activities/MainActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/notes/pro/activities/MainActivity.kt
@@ -904,7 +904,7 @@ class MainActivity : SimpleActivity() {
         }
     }
 
-    private fun requestUnlockNotes(callback: (List<Long>) -> Unit) {
+    private fun requestUnlockNotes(callback: (unlockedNoteIds: List<Long>) -> Unit) {
         val lockedNotes = mNotes.filter { it.isLocked() }
         if (lockedNotes.isNotEmpty()) {
             runOnUiThread {
@@ -919,10 +919,10 @@ class MainActivity : SimpleActivity() {
         ensureBackgroundThread {
             NotesHelper(this).getNotes {
                 mNotes = it
-                requestUnlockNotes { unlockedIds ->
+                requestUnlockNotes { unlockedNoteIds ->
                     toast(R.string.exporting)
                     val notesExporter = NotesExporter(this)
-                    notesExporter.exportNotes(mNotes, unlockedIds, outputStream) { result ->
+                    notesExporter.exportNotes(mNotes, unlockedNoteIds, outputStream) { result ->
                         val toastId = when (result) {
                             NotesExporter.ExportResult.EXPORT_OK -> R.string.exporting_successful
                             else -> R.string.exporting_failed
@@ -1030,7 +1030,7 @@ class MainActivity : SimpleActivity() {
         ensureBackgroundThread {
             NotesHelper(this).getNotes { notes ->
                 mNotes = notes
-                requestUnlockNotes { unlockedIds ->
+                requestUnlockNotes { unlockedNoteIds ->
                     ExportFilesDialog(this, mNotes) { parent, extension ->
                         val items = arrayListOf(
                             RadioItem(EXPORT_FILE_SYNC, getString(R.string.update_file_at_note)),
@@ -1040,7 +1040,7 @@ class MainActivity : SimpleActivity() {
                         RadioGroupDialog(this, items) { any ->
                             val syncFile = any as Int == EXPORT_FILE_SYNC
                             var failCount = 0
-                            mNotes.filter { !it.isLocked() || it.id in unlockedIds }.forEachIndexed { index, note ->
+                            mNotes.filter { !it.isLocked() || it.id in unlockedNoteIds }.forEachIndexed { index, note ->
                                 val filename = if (extension.isEmpty()) note.title else "${note.title}.$extension"
                                 val file = File(parent, filename)
                                 if (!filename.isAValidFilename()) {

--- a/app/src/main/kotlin/com/simplemobiletools/notes/pro/activities/MainActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/notes/pro/activities/MainActivity.kt
@@ -904,17 +904,24 @@ class MainActivity : SimpleActivity() {
         }
     }
 
-    private fun exportNotesTo(outputStream: OutputStream?) {
-        toast(R.string.exporting)
-        ensureBackgroundThread {
-            val notesExporter = NotesExporter(this)
-            notesExporter.exportNotes(outputStream) {
-                val toastId = when (it) {
-                    NotesExporter.ExportResult.EXPORT_OK -> R.string.exporting_successful
-                    else -> R.string.exporting_failed
-                }
+    private fun requestUnlockNotes(callback: (List<Long>) -> Unit) {
+        val lockedNotes = mNotes.filter { it.isLocked() }
+        UnlockNotesDialog(this, lockedNotes, callback)
+    }
 
-                toast(toastId)
+    private fun exportNotesTo(outputStream: OutputStream?) {
+        requestUnlockNotes { unlockedIds ->
+            toast(R.string.exporting)
+            ensureBackgroundThread {
+                val notesExporter = NotesExporter(this)
+                notesExporter.exportNotes(outputStream, unlockedIds) {
+                    val toastId = when (it) {
+                        NotesExporter.ExportResult.EXPORT_OK -> R.string.exporting_successful
+                        else -> R.string.exporting_failed
+                    }
+
+                    toast(toastId)
+                }
             }
         }
     }
@@ -1011,49 +1018,51 @@ class MainActivity : SimpleActivity() {
     }
 
     private fun exportAllNotesBelowQ() {
-        ExportFilesDialog(this, mNotes) { parent, extension ->
-            val items = arrayListOf(
-                RadioItem(EXPORT_FILE_SYNC, getString(R.string.update_file_at_note)),
-                RadioItem(EXPORT_FILE_NO_SYNC, getString(R.string.only_export_file_content))
-            )
+        requestUnlockNotes { unlockedIds ->
+            ExportFilesDialog(this, mNotes) { parent, extension ->
+                val items = arrayListOf(
+                    RadioItem(EXPORT_FILE_SYNC, getString(R.string.update_file_at_note)),
+                    RadioItem(EXPORT_FILE_NO_SYNC, getString(R.string.only_export_file_content))
+                )
 
-            RadioGroupDialog(this, items) {
-                val syncFile = it as Int == EXPORT_FILE_SYNC
-                var failCount = 0
-                NotesHelper(this).getNotes {
-                    mNotes = it
-                    mNotes.filter { !it.isLocked() }.forEachIndexed { index, note ->
-                        val filename = if (extension.isEmpty()) note.title else "${note.title}.$extension"
-                        val file = File(parent, filename)
-                        if (!filename.isAValidFilename()) {
-                            toast(String.format(getString(R.string.filename_invalid_characters_placeholder, filename)))
-                        } else {
-                            val noteStoredValue = note.getNoteStoredValue(this) ?: ""
-                            tryExportNoteValueToFile(file.absolutePath, mCurrentNote.title, note.value, false) { exportedSuccessfully ->
-                                if (exportedSuccessfully) {
-                                    if (syncFile) {
-                                        note.path = file.absolutePath
-                                        note.value = ""
-                                    } else {
-                                        note.path = ""
-                                        note.value = noteStoredValue
+                RadioGroupDialog(this, items) { any ->
+                    val syncFile = any as Int == EXPORT_FILE_SYNC
+                    var failCount = 0
+                    NotesHelper(this).getNotes { notes ->
+                        mNotes = notes
+                        mNotes.filter { !it.isLocked() || it.id in unlockedIds }.forEachIndexed { index, note ->
+                            val filename = if (extension.isEmpty()) note.title else "${note.title}.$extension"
+                            val file = File(parent, filename)
+                            if (!filename.isAValidFilename()) {
+                                toast(String.format(getString(R.string.filename_invalid_characters_placeholder, filename)))
+                            } else {
+                                val noteStoredValue = note.getNoteStoredValue(this) ?: ""
+                                tryExportNoteValueToFile(file.absolutePath, mCurrentNote.title, note.value, false) { exportedSuccessfully ->
+                                    if (exportedSuccessfully) {
+                                        if (syncFile) {
+                                            note.path = file.absolutePath
+                                            note.value = ""
+                                        } else {
+                                            note.path = ""
+                                            note.value = noteStoredValue
+                                        }
+
+                                        NotesHelper(this).insertOrUpdateNote(note)
                                     }
 
-                                    NotesHelper(this).insertOrUpdateNote(note)
-                                }
+                                    if (mCurrentNote.id == note.id) {
+                                        mCurrentNote.value = note.value
+                                        mCurrentNote.path = note.path
+                                        getPagerAdapter().updateCurrentNoteData(view_pager.currentItem, mCurrentNote.path, mCurrentNote.value)
+                                    }
 
-                                if (mCurrentNote.id == note.id) {
-                                    mCurrentNote.value = note.value
-                                    mCurrentNote.path = note.path
-                                    getPagerAdapter().updateCurrentNoteData(view_pager.currentItem, mCurrentNote.path, mCurrentNote.value)
-                                }
+                                    if (!exportedSuccessfully) {
+                                        failCount++
+                                    }
 
-                                if (!exportedSuccessfully) {
-                                    failCount++
-                                }
-
-                                if (index == mNotes.size - 1) {
-                                    toast(if (failCount == 0) R.string.exporting_successful else R.string.exporting_some_entries_failed)
+                                    if (index == mNotes.size - 1) {
+                                        toast(if (failCount == 0) R.string.exporting_successful else R.string.exporting_some_entries_failed)
+                                    }
                                 }
                             }
                         }

--- a/app/src/main/kotlin/com/simplemobiletools/notes/pro/activities/MainActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/notes/pro/activities/MainActivity.kt
@@ -906,7 +906,11 @@ class MainActivity : SimpleActivity() {
 
     private fun requestUnlockNotes(callback: (List<Long>) -> Unit) {
         val lockedNotes = mNotes.filter { it.isLocked() }
-        UnlockNotesDialog(this, lockedNotes, callback)
+        if (lockedNotes.isNotEmpty()) {
+            UnlockNotesDialog(this, lockedNotes, callback)
+        } else {
+            callback(emptyList())
+        }
     }
 
     private fun exportNotesTo(outputStream: OutputStream?) {

--- a/app/src/main/kotlin/com/simplemobiletools/notes/pro/dialogs/NewNoteDialog.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/notes/pro/dialogs/NewNoteDialog.kt
@@ -24,16 +24,16 @@ class NewNoteDialog(val activity: Activity, title: String? = null, val setCheckl
             new_note_type.check(defaultType)
         }
 
-        view.note_title.setText(title)
+        view.locked_note_title.setText(title)
 
         activity.getAlertDialogBuilder()
             .setPositiveButton(R.string.ok, null)
             .setNegativeButton(R.string.cancel, null)
             .apply {
                 activity.setupDialogStuff(view, this, R.string.new_note) { alertDialog ->
-                    alertDialog.showKeyboard(view.note_title)
+                    alertDialog.showKeyboard(view.locked_note_title)
                     alertDialog.getButton(BUTTON_POSITIVE).setOnClickListener {
-                        val newTitle = view.note_title.value
+                        val newTitle = view.locked_note_title.value
                         ensureBackgroundThread {
                             when {
                                 newTitle.isEmpty() -> activity.toast(R.string.no_title)

--- a/app/src/main/kotlin/com/simplemobiletools/notes/pro/dialogs/RenameNoteDialog.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/notes/pro/dialogs/RenameNoteDialog.kt
@@ -18,16 +18,16 @@ class RenameNoteDialog(val activity: SimpleActivity, val note: Note, val current
 
     init {
         val view = activity.layoutInflater.inflate(R.layout.dialog_rename_note, null)
-        view.note_title.setText(note.title)
+        view.locked_note_title.setText(note.title)
 
         activity.getAlertDialogBuilder()
             .setPositiveButton(R.string.ok, null)
             .setNegativeButton(R.string.cancel, null)
             .apply {
                 activity.setupDialogStuff(view, this, R.string.rename_note) { alertDialog ->
-                    alertDialog.showKeyboard(view.note_title)
+                    alertDialog.showKeyboard(view.locked_note_title)
                     alertDialog.getButton(BUTTON_POSITIVE).setOnClickListener {
-                        val title = view.note_title.value
+                        val title = view.locked_note_title.value
                         ensureBackgroundThread {
                             newTitleConfirmed(title, alertDialog)
                         }

--- a/app/src/main/kotlin/com/simplemobiletools/notes/pro/dialogs/UnlockNotesDialog.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/notes/pro/dialogs/UnlockNotesDialog.kt
@@ -2,6 +2,7 @@ package com.simplemobiletools.notes.pro.dialogs
 
 import android.content.DialogInterface
 import android.view.ViewGroup
+import androidx.appcompat.app.AlertDialog
 import com.simplemobiletools.commons.activities.BaseSimpleActivity
 import com.simplemobiletools.commons.extensions.*
 import com.simplemobiletools.notes.pro.R
@@ -9,7 +10,8 @@ import com.simplemobiletools.notes.pro.models.Note
 import kotlinx.android.synthetic.main.dialog_unlock_notes.view.*
 import kotlinx.android.synthetic.main.item_locked_note.view.*
 
-class UnlockNotesDialog(val activity: BaseSimpleActivity, notes: List<Note>, callback: (unlockedNoteIds: List<Long>) -> Unit) {
+class UnlockNotesDialog(val activity: BaseSimpleActivity, val notes: List<Note>, callback: (unlockedNoteIds: List<Long>) -> Unit) {
+    private var dialog: AlertDialog? = null
     private val view = activity.layoutInflater.inflate(R.layout.dialog_unlock_notes, null) as ViewGroup
     private val redColor = activity.getColor(R.color.md_red)
     private val greenColor = activity.getColor(R.color.md_green)
@@ -20,10 +22,11 @@ class UnlockNotesDialog(val activity: BaseSimpleActivity, notes: List<Note>, cal
             addLockedNoteView(note)
         }
         activity.getAlertDialogBuilder()
-            .setPositiveButton(R.string.ok, null)
+            .setPositiveButton(R.string.skip, null)
             .setNegativeButton(R.string.cancel, null)
             .apply {
                 activity.setupDialogStuff(view, this, R.string.unlock_notes, cancelOnTouchOutside = false) { alertDialog ->
+                    dialog = alertDialog
                     alertDialog.getButton(DialogInterface.BUTTON_POSITIVE).setOnClickListener {
                         callback(unlockedNoteIds)
                         alertDialog.dismiss()
@@ -49,6 +52,7 @@ class UnlockNotesDialog(val activity: BaseSimpleActivity, notes: List<Note>, cal
                                 setImageResource(R.drawable.ic_lock_open_vector)
                                 applyColorFilter(greenColor)
                             }
+                            updatePositiveButton()
                         }
                     )
                 } else {
@@ -57,8 +61,17 @@ class UnlockNotesDialog(val activity: BaseSimpleActivity, notes: List<Note>, cal
                         setImageResource(R.drawable.ic_lock_vector)
                         applyColorFilter(redColor)
                     }
+                    updatePositiveButton()
                 }
             }
+        }
+    }
+
+    private fun updatePositiveButton() {
+        dialog?.getButton(DialogInterface.BUTTON_POSITIVE)?.text = if (unlockedNoteIds.isNotEmpty()) {
+            activity.getString(R.string.ok)
+        } else {
+            activity.getString(R.string.skip)
         }
     }
 }

--- a/app/src/main/kotlin/com/simplemobiletools/notes/pro/dialogs/UnlockNotesDialog.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/notes/pro/dialogs/UnlockNotesDialog.kt
@@ -21,6 +21,7 @@ class UnlockNotesDialog(val activity: BaseSimpleActivity, val notes: List<Note>,
         for (note in notes) {
             addLockedNoteView(note)
         }
+
         activity.getAlertDialogBuilder()
             .setPositiveButton(R.string.skip, null)
             .setNegativeButton(R.string.cancel, null)

--- a/app/src/main/kotlin/com/simplemobiletools/notes/pro/dialogs/UnlockNotesDialog.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/notes/pro/dialogs/UnlockNotesDialog.kt
@@ -1,0 +1,64 @@
+package com.simplemobiletools.notes.pro.dialogs
+
+import android.content.DialogInterface
+import android.view.ViewGroup
+import com.simplemobiletools.commons.activities.BaseSimpleActivity
+import com.simplemobiletools.commons.extensions.*
+import com.simplemobiletools.notes.pro.R
+import com.simplemobiletools.notes.pro.models.Note
+import kotlinx.android.synthetic.main.dialog_unlock_notes.view.*
+import kotlinx.android.synthetic.main.item_locked_note.view.*
+
+class UnlockNotesDialog(val activity: BaseSimpleActivity, notes: List<Note>, callback: (unlockedNoteIds: List<Long>) -> Unit) {
+    private val view = activity.layoutInflater.inflate(R.layout.dialog_unlock_notes, null) as ViewGroup
+    private val redColor = activity.getColor(R.color.md_red)
+    private val greenColor = activity.getColor(R.color.md_green)
+    private val unlockedNoteIds = mutableListOf<Long>()
+
+    init {
+        for (note in notes) {
+            addLockedNoteView(note)
+        }
+        activity.getAlertDialogBuilder()
+            .setPositiveButton(R.string.ok, null)
+            .setNegativeButton(R.string.cancel, null)
+            .apply {
+                activity.setupDialogStuff(view, this, R.string.unlock_notes, cancelOnTouchOutside = false) { alertDialog ->
+                    alertDialog.getButton(DialogInterface.BUTTON_POSITIVE).setOnClickListener {
+                        callback(unlockedNoteIds)
+                        alertDialog.dismiss()
+                    }
+                }
+            }
+    }
+
+    private fun addLockedNoteView(note: Note) {
+        activity.layoutInflater.inflate(R.layout.item_locked_note, null).apply {
+            view.notes_holder.addView(this)
+            activity.updateTextColors(view.notes_holder)
+            locked_note_title.text = note.title
+            locked_unlocked_image.applyColorFilter(redColor)
+            locked_note_holder.setOnClickListener {
+                if (note.id !in unlockedNoteIds) {
+                    activity.performSecurityCheck(
+                        protectionType = note.protectionType,
+                        requiredHash = note.protectionHash,
+                        successCallback = { _, _ ->
+                            unlockedNoteIds.add(note.id!!)
+                            locked_unlocked_image.apply {
+                                setImageResource(R.drawable.ic_lock_open_vector)
+                                applyColorFilter(greenColor)
+                            }
+                        }
+                    )
+                } else {
+                    unlockedNoteIds.remove(note.id)
+                    locked_unlocked_image.apply {
+                        setImageResource(R.drawable.ic_lock_vector)
+                        applyColorFilter(redColor)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/com/simplemobiletools/notes/pro/helpers/NotesExporter.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/notes/pro/helpers/NotesExporter.kt
@@ -5,7 +5,6 @@ import com.google.gson.Gson
 import com.google.gson.stream.JsonWriter
 import com.simplemobiletools.commons.helpers.PROTECTION_NONE
 import com.simplemobiletools.commons.helpers.ensureBackgroundThread
-import com.simplemobiletools.notes.pro.extensions.notesDB
 import com.simplemobiletools.notes.pro.models.Note
 import java.io.OutputStream
 
@@ -16,7 +15,7 @@ class NotesExporter(private val context: Context) {
 
     private val gson = Gson()
 
-    fun exportNotes(outputStream: OutputStream?, unlockedNoteIds: List<Long>, callback: (result: ExportResult) -> Unit) {
+    fun exportNotes(notes: List<Note>, unlockedNoteIds: List<Long>, outputStream: OutputStream?, callback: (result: ExportResult) -> Unit) {
         ensureBackgroundThread {
             if (outputStream == null) {
                 callback.invoke(ExportResult.EXPORT_FAIL)
@@ -27,7 +26,6 @@ class NotesExporter(private val context: Context) {
                 try {
                     var written = 0
                     writer.beginArray()
-                    val notes = context.notesDB.getNotes() as ArrayList<Note>
                     for (note in notes) {
                         if (!note.isLocked() || note.id in unlockedNoteIds) {
                             val noteToSave = getNoteToExport(note)

--- a/app/src/main/kotlin/com/simplemobiletools/notes/pro/helpers/NotesExporter.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/notes/pro/helpers/NotesExporter.kt
@@ -16,7 +16,7 @@ class NotesExporter(private val context: Context) {
 
     private val gson = Gson()
 
-    fun exportNotes(outputStream: OutputStream?, callback: (result: ExportResult) -> Unit) {
+    fun exportNotes(outputStream: OutputStream?, unlockedNoteIds: List<Long>, callback: (result: ExportResult) -> Unit) {
         ensureBackgroundThread {
             if (outputStream == null) {
                 callback.invoke(ExportResult.EXPORT_FAIL)
@@ -29,7 +29,7 @@ class NotesExporter(private val context: Context) {
                     writer.beginArray()
                     val notes = context.notesDB.getNotes() as ArrayList<Note>
                     for (note in notes) {
-                        if (note.protectionType == PROTECTION_NONE) {
+                        if (!note.isLocked() || note.id in unlockedNoteIds) {
                             val noteToSave = getNoteToExport(note)
                             writer.jsonValue(gson.toJson(noteToSave))
                             written++

--- a/app/src/main/res/drawable/ic_lock_open_vector.xml
+++ b/app/src/main/res/drawable/ic_lock_open_vector.xml
@@ -1,0 +1,3 @@
+<vector android:height="24dp" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M12 17c1.1 0 2-0.9 2-2s-0.9-2-2-2-2 0.9-2 2 0.9 2 2 2zm6-9h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6h1.9c0-1.71 1.39-3.1 3.1-3.1 1.71 0 3.1 1.39 3.1 3.1v2H6c-1.1 0-2 0.9-2 2v10c0 1.1 0.9 2 2 2h12c1.1 0 2-0.9 2-2V10c0-1.1-0.9-2-2-2zm0 12H6V10h12v10z"/>
+</vector>

--- a/app/src/main/res/layout/dialog_new_note.xml
+++ b/app/src/main/res/layout/dialog_new_note.xml
@@ -17,7 +17,7 @@
         android:hint="@string/label">
 
         <com.google.android.material.textfield.TextInputEditText
-            android:id="@+id/note_title"
+            android:id="@+id/locked_note_title"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:inputType="textCapSentences"

--- a/app/src/main/res/layout/dialog_rename_note.xml
+++ b/app/src/main/res/layout/dialog_rename_note.xml
@@ -14,7 +14,7 @@
         android:hint="@string/title">
 
         <com.google.android.material.textfield.TextInputEditText
-            android:id="@+id/note_title"
+            android:id="@+id/locked_note_title"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:inputType="textCapSentences"

--- a/app/src/main/res/layout/dialog_unlock_notes.xml
+++ b/app/src/main/res/layout/dialog_unlock_notes.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/dialog_holder"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:fillViewport="true"
+    android:paddingTop="@dimen/activity_margin">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
+
+        <com.simplemobiletools.commons.views.MyTextView
+            android:id="@+id/found_locked_notes_info"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="@dimen/big_margin"
+            android:layout_marginTop="@dimen/small_margin"
+            android:layout_marginBottom="@dimen/activity_margin"
+            android:text="@string/found_locked_notes_info" />
+
+        <LinearLayout
+            android:id="@+id/notes_holder"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical" />
+
+    </LinearLayout>
+</ScrollView>

--- a/app/src/main/res/layout/item_locked_note.xml
+++ b/app/src/main/res/layout/item_locked_note.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/locked_note_holder"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="@drawable/ripple_background"
+    android:clickable="true"
+    android:focusable="true"
+    android:paddingHorizontal="@dimen/normal_margin">
+
+    <com.simplemobiletools.commons.views.MyTextView
+        android:id="@+id/locked_note_title"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:paddingStart="@dimen/activity_margin"
+        android:textSize="@dimen/bigger_text_size"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/locked_unlocked_image"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="Passwords" />
+
+    <ImageView
+        android:id="@+id/locked_unlocked_image"
+        android:layout_width="@dimen/fab_size"
+        android:layout_height="@dimen/fab_size"
+        android:paddingVertical="@dimen/activity_margin"
+        android:src="@drawable/ic_lock_vector"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -25,7 +25,7 @@
     <string name="lock_note">Lock note</string>
     <string name="unlock_note">إلغاء تأمين الملاحظة</string>
     <string name="unlock_notes">Unlock notes</string>
-    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or tap \"OK\" to skip exporting locked notes.</string>
+    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or skip exporting them.</string>
     <string name="note_content_locked">محتوى الملاحظات مؤمن.</string>
     <string name="show_content">إظهار المحتوى</string>
     <string name="locking_warning">تحذير: إذا نسيت كلمة مرور الملاحظات، فلن تتمكن من استعادتها أو الوصول إلى محتوى الملاحظات بعد الآن.</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -24,6 +24,8 @@
     <string name="text_note">ملاحظة نصية</string>
     <string name="lock_note">Lock note</string>
     <string name="unlock_note">إلغاء تأمين الملاحظة</string>
+    <string name="unlock_notes">Unlock notes</string>
+    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or tap \"OK\" to skip exporting locked notes.</string>
     <string name="note_content_locked">محتوى الملاحظات مؤمن.</string>
     <string name="show_content">إظهار المحتوى</string>
     <string name="locking_warning">تحذير: إذا نسيت كلمة مرور الملاحظات، فلن تتمكن من استعادتها أو الوصول إلى محتوى الملاحظات بعد الآن.</string>

--- a/app/src/main/res/values-az/strings.xml
+++ b/app/src/main/res/values-az/strings.xml
@@ -24,6 +24,8 @@
     <string name="text_note">Text note</string>
     <string name="lock_note">Lock note</string>
     <string name="unlock_note">Unlock note</string>
+    <string name="unlock_notes">Unlock notes</string>
+    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or tap \"OK\" to skip exporting locked notes.</string>
     <string name="note_content_locked">The notes\' content is locked.</string>
     <string name="show_content">Show content</string>
     <string name="locking_warning">WARNING: If you forget the notes\' password, you won\'t be able to recover it or access the notes\' content anymore.</string>

--- a/app/src/main/res/values-az/strings.xml
+++ b/app/src/main/res/values-az/strings.xml
@@ -25,7 +25,7 @@
     <string name="lock_note">Lock note</string>
     <string name="unlock_note">Unlock note</string>
     <string name="unlock_notes">Unlock notes</string>
-    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or tap \"OK\" to skip exporting locked notes.</string>
+    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or skip exporting them.</string>
     <string name="note_content_locked">The notes\' content is locked.</string>
     <string name="show_content">Show content</string>
     <string name="locking_warning">WARNING: If you forget the notes\' password, you won\'t be able to recover it or access the notes\' content anymore.</string>

--- a/app/src/main/res/values-be/strings.xml
+++ b/app/src/main/res/values-be/strings.xml
@@ -24,6 +24,8 @@
     <string name="text_note">Тэкставая нататка</string>
     <string name="lock_note">Блакаваць нататку</string>
     <string name="unlock_note">Разблакаваць нататку</string>
+    <string name="unlock_notes">Unlock notes</string>
+    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or tap \"OK\" to skip exporting locked notes.</string>
     <string name="note_content_locked">Змесціва нататкі заблакавана.</string>
     <string name="show_content">Паказаць змесціва</string>
     <string name="locking_warning">ПАПЯРЭДЖАННЕ: Калі вы забудзеце пароль, вы больш не зможаце аднавіць яго альбо атрымаць доступ да змесціва нататак.</string>

--- a/app/src/main/res/values-be/strings.xml
+++ b/app/src/main/res/values-be/strings.xml
@@ -25,7 +25,7 @@
     <string name="lock_note">Блакаваць нататку</string>
     <string name="unlock_note">Разблакаваць нататку</string>
     <string name="unlock_notes">Unlock notes</string>
-    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or tap \"OK\" to skip exporting locked notes.</string>
+    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or skip exporting them.</string>
     <string name="note_content_locked">Змесціва нататкі заблакавана.</string>
     <string name="show_content">Паказаць змесціва</string>
     <string name="locking_warning">ПАПЯРЭДЖАННЕ: Калі вы забудзеце пароль, вы больш не зможаце аднавіць яго альбо атрымаць доступ да змесціва нататак.</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -25,7 +25,7 @@
     <string name="lock_note">Бележка за заключване</string>
     <string name="unlock_note">Бележка за отключване</string>
     <string name="unlock_notes">Unlock notes</string>
-    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or tap \"OK\" to skip exporting locked notes.</string>
+    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or skip exporting them.</string>
     <string name="note_content_locked">Съдържанието на бележките е заключено.</string>
     <string name="show_content">Покажи съдържанието</string>
     <string name="locking_warning">ПРЕДУПРЕЖДЕНИЕ: Ако забравите паролата на бележките, вече няма да можете да я възстановите или да получите достъп до съдържанието на бележките.</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -24,6 +24,8 @@
     <string name="text_note">Текстова бележка</string>
     <string name="lock_note">Бележка за заключване</string>
     <string name="unlock_note">Бележка за отключване</string>
+    <string name="unlock_notes">Unlock notes</string>
+    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or tap \"OK\" to skip exporting locked notes.</string>
     <string name="note_content_locked">Съдържанието на бележките е заключено.</string>
     <string name="show_content">Покажи съдържанието</string>
     <string name="locking_warning">ПРЕДУПРЕЖДЕНИЕ: Ако забравите паролата на бележките, вече няма да можете да я възстановите или да получите достъп до съдържанието на бележките.</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -25,7 +25,7 @@
     <string name="lock_note">Bloqueja la nota</string>
     <string name="unlock_note">Desbloqueja la nota</string>
     <string name="unlock_notes">Unlock notes</string>
-    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or tap \"OK\" to skip exporting locked notes.</string>
+    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or skip exporting them.</string>
     <string name="note_content_locked">El contingut de la nota està bloquejat.</string>
     <string name="show_content">Mostra el contingut</string>
     <string name="locking_warning">AVÍS: Si oblideu la contrasenya de la nota, ja no podreu recuperar-la ni accedir al contingut de les notes.</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -24,6 +24,8 @@
     <string name="text_note">Nota de text</string>
     <string name="lock_note">Bloqueja la nota</string>
     <string name="unlock_note">Desbloqueja la nota</string>
+    <string name="unlock_notes">Unlock notes</string>
+    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or tap \"OK\" to skip exporting locked notes.</string>
     <string name="note_content_locked">El contingut de la nota està bloquejat.</string>
     <string name="show_content">Mostra el contingut</string>
     <string name="locking_warning">AVÍS: Si oblideu la contrasenya de la nota, ja no podreu recuperar-la ni accedir al contingut de les notes.</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -25,7 +25,7 @@
     <string name="lock_note">Zamknout poznámku</string>
     <string name="unlock_note">Odemknout poznámku</string>
     <string name="unlock_notes">Unlock notes</string>
-    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or tap \"OK\" to skip exporting locked notes.</string>
+    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or skip exporting them.</string>
     <string name="note_content_locked">Obsah této poznámky je uzamčen.</string>
     <string name="show_content">Zobrazit obsah</string>
     <string name="locking_warning">UPOZORNĚNÍ: Pokud zapomenete heslo k poznámce, už ji nebudete schopni obnovit nebo získat přístup k jejímu obsahu.</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -24,6 +24,8 @@
     <string name="text_note">Textová poznámka</string>
     <string name="lock_note">Zamknout poznámku</string>
     <string name="unlock_note">Odemknout poznámku</string>
+    <string name="unlock_notes">Unlock notes</string>
+    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or tap \"OK\" to skip exporting locked notes.</string>
     <string name="note_content_locked">Obsah této poznámky je uzamčen.</string>
     <string name="show_content">Zobrazit obsah</string>
     <string name="locking_warning">UPOZORNĚNÍ: Pokud zapomenete heslo k poznámce, už ji nebudete schopni obnovit nebo získat přístup k jejímu obsahu.</string>

--- a/app/src/main/res/values-cy/strings.xml
+++ b/app/src/main/res/values-cy/strings.xml
@@ -25,7 +25,7 @@
     <string name="lock_note">Lock note</string>
     <string name="unlock_note">Unlock note</string>
     <string name="unlock_notes">Unlock notes</string>
-    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or tap \"OK\" to skip exporting locked notes.</string>
+    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or skip exporting them.</string>
     <string name="note_content_locked">The notes\' content is locked.</string>
     <string name="show_content">Show content</string>
     <string name="locking_warning">WARNING: If you forget the notes\' password, you won\'t be able to recover it or access the notes\' content anymore.</string>

--- a/app/src/main/res/values-cy/strings.xml
+++ b/app/src/main/res/values-cy/strings.xml
@@ -24,6 +24,8 @@
     <string name="text_note">Nodyn testun</string>
     <string name="lock_note">Lock note</string>
     <string name="unlock_note">Unlock note</string>
+    <string name="unlock_notes">Unlock notes</string>
+    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or tap \"OK\" to skip exporting locked notes.</string>
     <string name="note_content_locked">The notes\' content is locked.</string>
     <string name="show_content">Show content</string>
     <string name="locking_warning">WARNING: If you forget the notes\' password, you won\'t be able to recover it or access the notes\' content anymore.</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -25,7 +25,7 @@
     <string name="lock_note">Lock note</string>
     <string name="unlock_note">Lås note op</string>
     <string name="unlock_notes">Unlock notes</string>
-    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or tap \"OK\" to skip exporting locked notes.</string>
+    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or skip exporting them.</string>
     <string name="note_content_locked">Noternes indhold er låst.</string>
     <string name="show_content">Vis indhold</string>
     <string name="locking_warning">ADVARSEL: Hvis du glemmer noternes adgangskode, kan du ikke gendanne den eller få adgang til noternes indhold længere.</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -24,6 +24,8 @@
     <string name="text_note">Tekstnote</string>
     <string name="lock_note">Lock note</string>
     <string name="unlock_note">Lås note op</string>
+    <string name="unlock_notes">Unlock notes</string>
+    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or tap \"OK\" to skip exporting locked notes.</string>
     <string name="note_content_locked">Noternes indhold er låst.</string>
     <string name="show_content">Vis indhold</string>
     <string name="locking_warning">ADVARSEL: Hvis du glemmer noternes adgangskode, kan du ikke gendanne den eller få adgang til noternes indhold længere.</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -25,7 +25,7 @@
     <string name="lock_note">Notiz sperren</string>
     <string name="unlock_note">Notiz entsperren</string>
     <string name="unlock_notes">Unlock notes</string>
-    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or tap \"OK\" to skip exporting locked notes.</string>
+    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or skip exporting them.</string>
     <string name="note_content_locked">Der Inhalt der Notizen ist gesperrt.</string>
     <string name="show_content">Inhalt anzeigen</string>
     <string name="locking_warning">ACHTUNG: Wenn du das Kennwort für die Notizen vergisst, kannst du sie nicht mehr wiederherstellen oder auf den Inhalt der Notizen zugreifen.</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -24,6 +24,8 @@
     <string name="text_note">Textnotiz</string>
     <string name="lock_note">Notiz sperren</string>
     <string name="unlock_note">Notiz entsperren</string>
+    <string name="unlock_notes">Unlock notes</string>
+    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or tap \"OK\" to skip exporting locked notes.</string>
     <string name="note_content_locked">Der Inhalt der Notizen ist gesperrt.</string>
     <string name="show_content">Inhalt anzeigen</string>
     <string name="locking_warning">ACHTUNG: Wenn du das Kennwort für die Notizen vergisst, kannst du sie nicht mehr wiederherstellen oder auf den Inhalt der Notizen zugreifen.</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -25,7 +25,7 @@
     <string name="lock_note">Κλείδωμα Σημείωσης</string>
     <string name="unlock_note">Ξεκλείδωμα Σημείωσης</string>
     <string name="unlock_notes">Unlock notes</string>
-    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or tap \"OK\" to skip exporting locked notes.</string>
+    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or skip exporting them.</string>
     <string name="note_content_locked">Το περιεχόμενο των σημειώσεων είναι κλειδωμένο.</string>
     <string name="show_content">Εμφάνιση περιεχομένου</string>
     <string name="locking_warning">ΠΡΟΣΟΧΗ: Εάν ξεχάσετε τον κωδικό των σημειώσεων, δεν θα μπορείτε πλέον να τον ανακτήσετε ή να αποκτήσετε πρόσβαση στο περιεχόμενό τους.</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -24,6 +24,8 @@
     <string name="text_note">Σημείωση κειμένου</string>
     <string name="lock_note">Κλείδωμα Σημείωσης</string>
     <string name="unlock_note">Ξεκλείδωμα Σημείωσης</string>
+    <string name="unlock_notes">Unlock notes</string>
+    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or tap \"OK\" to skip exporting locked notes.</string>
     <string name="note_content_locked">Το περιεχόμενο των σημειώσεων είναι κλειδωμένο.</string>
     <string name="show_content">Εμφάνιση περιεχομένου</string>
     <string name="locking_warning">ΠΡΟΣΟΧΗ: Εάν ξεχάσετε τον κωδικό των σημειώσεων, δεν θα μπορείτε πλέον να τον ανακτήσετε ή να αποκτήσετε πρόσβαση στο περιεχόμενό τους.</string>

--- a/app/src/main/res/values-eo/strings.xml
+++ b/app/src/main/res/values-eo/strings.xml
@@ -24,6 +24,8 @@
     <string name="text_note">Teksta noto</string>
     <string name="lock_note">Ŝlosi noton</string>
     <string name="unlock_note">Malŝlosi noton</string>
+    <string name="unlock_notes">Unlock notes</string>
+    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or tap \"OK\" to skip exporting locked notes.</string>
     <string name="note_content_locked">The notes\' content is locked.</string>
     <string name="show_content">Montri enhavon</string>
     <string name="locking_warning">WARNING: If you forget the notes\' password, you won\'t be able to recover it or access the notes\' content anymore.</string>

--- a/app/src/main/res/values-eo/strings.xml
+++ b/app/src/main/res/values-eo/strings.xml
@@ -25,7 +25,7 @@
     <string name="lock_note">Ŝlosi noton</string>
     <string name="unlock_note">Malŝlosi noton</string>
     <string name="unlock_notes">Unlock notes</string>
-    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or tap \"OK\" to skip exporting locked notes.</string>
+    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or skip exporting them.</string>
     <string name="note_content_locked">The notes\' content is locked.</string>
     <string name="show_content">Montri enhavon</string>
     <string name="locking_warning">WARNING: If you forget the notes\' password, you won\'t be able to recover it or access the notes\' content anymore.</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -25,7 +25,7 @@
     <string name="lock_note">Bloquear nota</string>
     <string name="unlock_note">Desbloquear nota</string>
     <string name="unlock_notes">Unlock notes</string>
-    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or tap \"OK\" to skip exporting locked notes.</string>
+    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or skip exporting them.</string>
     <string name="note_content_locked">El contenido de la nota está bloqueado.</string>
     <string name="show_content">Mostrar contenido</string>
     <string name="locking_warning">ADVERTENCIA: Si olvidas la contraseña de la nota, ya no podrás recuperarla o acceder a su contenido.</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -24,6 +24,8 @@
     <string name="text_note">Nota de texto</string>
     <string name="lock_note">Bloquear nota</string>
     <string name="unlock_note">Desbloquear nota</string>
+    <string name="unlock_notes">Unlock notes</string>
+    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or tap \"OK\" to skip exporting locked notes.</string>
     <string name="note_content_locked">El contenido de la nota está bloqueado.</string>
     <string name="show_content">Mostrar contenido</string>
     <string name="locking_warning">ADVERTENCIA: Si olvidas la contraseña de la nota, ya no podrás recuperarla o acceder a su contenido.</string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -25,7 +25,7 @@
     <string name="lock_note">Lukusta märge</string>
     <string name="unlock_note">Eemalda märkme lukustus</string>
     <string name="unlock_notes">Unlock notes</string>
-    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or tap \"OK\" to skip exporting locked notes.</string>
+    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or skip exporting them.</string>
     <string name="note_content_locked">Märkme sisu on lukustatud.</string>
     <string name="show_content">Näita sisu</string>
     <string name="locking_warning">HOIATUS: Kui sa unustad märkme salasõna, siis sa ei saa seda märget avada ega tema sisu lugeda.</string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -24,6 +24,8 @@
     <string name="text_note">Tekstimärge</string>
     <string name="lock_note">Lukusta märge</string>
     <string name="unlock_note">Eemalda märkme lukustus</string>
+    <string name="unlock_notes">Unlock notes</string>
+    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or tap \"OK\" to skip exporting locked notes.</string>
     <string name="note_content_locked">Märkme sisu on lukustatud.</string>
     <string name="show_content">Näita sisu</string>
     <string name="locking_warning">HOIATUS: Kui sa unustad märkme salasõna, siis sa ei saa seda märget avada ega tema sisu lugeda.</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -24,6 +24,8 @@
     <string name="text_note">یادداشت متنی</string>
     <string name="lock_note">قفل کردن یادداشت</string>
     <string name="unlock_note">باز کردن قفل یادداشت</string>
+    <string name="unlock_notes">Unlock notes</string>
+    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or tap \"OK\" to skip exporting locked notes.</string>
     <string name="note_content_locked">محتویات یادداشت، قفل است</string>
     <string name="show_content">نمایش محتویات</string>
     <string name="locking_warning">هشدار: اگر گذرواژهٔ یادداشت را فراموش کنید، دیگر قادر به بازیابی آن یا دسترسی به محتویات یادداشت نیستید.</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -25,7 +25,7 @@
     <string name="lock_note">قفل کردن یادداشت</string>
     <string name="unlock_note">باز کردن قفل یادداشت</string>
     <string name="unlock_notes">Unlock notes</string>
-    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or tap \"OK\" to skip exporting locked notes.</string>
+    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or skip exporting them.</string>
     <string name="note_content_locked">محتویات یادداشت، قفل است</string>
     <string name="show_content">نمایش محتویات</string>
     <string name="locking_warning">هشدار: اگر گذرواژهٔ یادداشت را فراموش کنید، دیگر قادر به بازیابی آن یا دسترسی به محتویات یادداشت نیستید.</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -25,7 +25,7 @@
     <string name="lock_note">Lukitse huomautus</string>
     <string name="unlock_note">Avaa muistiinpanon lukitus</string>
     <string name="unlock_notes">Unlock notes</string>
-    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or tap \"OK\" to skip exporting locked notes.</string>
+    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or skip exporting them.</string>
     <string name="note_content_locked">Muistiinpanon sisältö on lukittu.</string>
     <string name="show_content">Näytä sisältö</string>
     <string name="locking_warning">VAROITUS: Jos unohdat muistiinpanon salasanan, sitä ei ole mahdollista palauttaa etkä pääse enää käsiksi muistiinpanoon.</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -24,6 +24,8 @@
     <string name="text_note">Tekstimuistiinpano</string>
     <string name="lock_note">Lukitse huomautus</string>
     <string name="unlock_note">Avaa muistiinpanon lukitus</string>
+    <string name="unlock_notes">Unlock notes</string>
+    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or tap \"OK\" to skip exporting locked notes.</string>
     <string name="note_content_locked">Muistiinpanon sisältö on lukittu.</string>
     <string name="show_content">Näytä sisältö</string>
     <string name="locking_warning">VAROITUS: Jos unohdat muistiinpanon salasanan, sitä ei ole mahdollista palauttaa etkä pääse enää käsiksi muistiinpanoon.</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -24,6 +24,8 @@
     <string name="text_note">Texte</string>
     <string name="lock_note">Verrouiller la note</string>
     <string name="unlock_note">Déverrouiller la note</string>
+    <string name="unlock_notes">Unlock notes</string>
+    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or tap \"OK\" to skip exporting locked notes.</string>
     <string name="note_content_locked">Le contenu des notes est verrouillé.</string>
     <string name="show_content">Montrer le contenu</string>
     <string name="locking_warning">AVERTISSEMENT : Si vous oubliez le mot de passe des notes, vous ne pourrez plus le récupérer ni accéder au contenu des notes.</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -25,7 +25,7 @@
     <string name="lock_note">Verrouiller la note</string>
     <string name="unlock_note">Déverrouiller la note</string>
     <string name="unlock_notes">Unlock notes</string>
-    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or tap \"OK\" to skip exporting locked notes.</string>
+    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or skip exporting them.</string>
     <string name="note_content_locked">Le contenu des notes est verrouillé.</string>
     <string name="show_content">Montrer le contenu</string>
     <string name="locking_warning">AVERTISSEMENT : Si vous oubliez le mot de passe des notes, vous ne pourrez plus le récupérer ni accéder au contenu des notes.</string>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -24,6 +24,8 @@
     <string name="text_note">Nota de texto</string>
     <string name="lock_note">Lock note</string>
     <string name="unlock_note">Desbloqueala nota</string>
+    <string name="unlock_notes">Unlock notes</string>
+    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or tap \"OK\" to skip exporting locked notes.</string>
     <string name="note_content_locked">O contido das notas está bloqueado.</string>
     <string name="show_content">Mostralo contido</string>
     <string name="locking_warning">PERIGO: Se esqueces o contrasinal das notas, xa non poderás recuperalo nin acceder ao contido das notas.</string>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -25,7 +25,7 @@
     <string name="lock_note">Lock note</string>
     <string name="unlock_note">Desbloqueala nota</string>
     <string name="unlock_notes">Unlock notes</string>
-    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or tap \"OK\" to skip exporting locked notes.</string>
+    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or skip exporting them.</string>
     <string name="note_content_locked">O contido das notas está bloqueado.</string>
     <string name="show_content">Mostralo contido</string>
     <string name="locking_warning">PERIGO: Se esqueces o contrasinal das notas, xa non poderás recuperalo nin acceder ao contido das notas.</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -24,6 +24,8 @@
     <string name="text_note">Tekstualna bilješka</string>
     <string name="lock_note">Zaključaj bilješku</string>
     <string name="unlock_note">Otključaj bilješku</string>
+    <string name="unlock_notes">Unlock notes</string>
+    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or tap \"OK\" to skip exporting locked notes.</string>
     <string name="note_content_locked">Sadržaj bilješke je zaključan.</string>
     <string name="show_content">Prikaži sadržaj</string>
     <string name="locking_warning">UPOZORENJE: Ako zaboraviš lozinku bilješke, više je nećeš moći obnoviti niti pristupiti njenom sadržaju.</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -25,7 +25,7 @@
     <string name="lock_note">Zaključaj bilješku</string>
     <string name="unlock_note">Otključaj bilješku</string>
     <string name="unlock_notes">Unlock notes</string>
-    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or tap \"OK\" to skip exporting locked notes.</string>
+    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or skip exporting them.</string>
     <string name="note_content_locked">Sadržaj bilješke je zaključan.</string>
     <string name="show_content">Prikaži sadržaj</string>
     <string name="locking_warning">UPOZORENJE: Ako zaboraviš lozinku bilješke, više je nećeš moći obnoviti niti pristupiti njenom sadržaju.</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -25,7 +25,7 @@
     <string name="lock_note">Jegyzet zárolása</string>
     <string name="unlock_note">Jegyzet feloldása</string>
     <string name="unlock_notes">Unlock notes</string>
-    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or tap \"OK\" to skip exporting locked notes.</string>
+    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or skip exporting them.</string>
     <string name="note_content_locked">A jegyzet tartalma zárolva van.</string>
     <string name="show_content">Tartalom megjelenítése</string>
     <string name="locking_warning">FIGYELMEZTETÉS: Ha elfelejti a jegyzetek jelszavát, akkor többé nem fogja tudni helyreállítani vagy elérni a jegyzetek tartalmát.</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -24,6 +24,8 @@
     <string name="text_note">Szöveges jegyzet</string>
     <string name="lock_note">Jegyzet zárolása</string>
     <string name="unlock_note">Jegyzet feloldása</string>
+    <string name="unlock_notes">Unlock notes</string>
+    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or tap \"OK\" to skip exporting locked notes.</string>
     <string name="note_content_locked">A jegyzet tartalma zárolva van.</string>
     <string name="show_content">Tartalom megjelenítése</string>
     <string name="locking_warning">FIGYELMEZTETÉS: Ha elfelejti a jegyzetek jelszavát, akkor többé nem fogja tudni helyreállítani vagy elérni a jegyzetek tartalmát.</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -24,6 +24,8 @@
     <string name="text_note">Catatan teks</string>
     <string name="lock_note">Lock note</string>
     <string name="unlock_note">Buka kunci kota</string>
+    <string name="unlock_notes">Unlock notes</string>
+    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or tap \"OK\" to skip exporting locked notes.</string>
     <string name="note_content_locked">Konten catatan terkunci.</string>
     <string name="show_content">Tampilkan konten</string>
     <string name="locking_warning">PERINGATAN: Jika Anda lupa kata sandi catatan, Anda tidak akan dapat memulihkan atau mengakses konten catatan.</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -25,7 +25,7 @@
     <string name="lock_note">Lock note</string>
     <string name="unlock_note">Buka kunci kota</string>
     <string name="unlock_notes">Unlock notes</string>
-    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or tap \"OK\" to skip exporting locked notes.</string>
+    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or skip exporting them.</string>
     <string name="note_content_locked">Konten catatan terkunci.</string>
     <string name="show_content">Tampilkan konten</string>
     <string name="locking_warning">PERINGATAN: Jika Anda lupa kata sandi catatan, Anda tidak akan dapat memulihkan atau mengakses konten catatan.</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -24,6 +24,8 @@
     <string name="text_note">Nota di testo</string>
     <string name="lock_note">Lock note</string>
     <string name="unlock_note">Sblocca la nota</string>
+    <string name="unlock_notes">Unlock notes</string>
+    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or tap \"OK\" to skip exporting locked notes.</string>
     <string name="note_content_locked">Il contenuto delle note è bloccato.</string>
     <string name="show_content">Mostra il contenuto</string>
     <string name="locking_warning">ATTENZIONE: Se dimentichi la password delle note, non sarai più in grado di recuperarla o di accedere al contenuto delle note.</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -25,7 +25,7 @@
     <string name="lock_note">Lock note</string>
     <string name="unlock_note">Sblocca la nota</string>
     <string name="unlock_notes">Unlock notes</string>
-    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or tap \"OK\" to skip exporting locked notes.</string>
+    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or skip exporting them.</string>
     <string name="note_content_locked">Il contenuto delle note è bloccato.</string>
     <string name="show_content">Mostra il contenuto</string>
     <string name="locking_warning">ATTENZIONE: Se dimentichi la password delle note, non sarai più in grado di recuperarla o di accedere al contenuto delle note.</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -25,7 +25,7 @@
     <string name="lock_note">נעל פתק</string>
     <string name="unlock_note">בטל נעילת פתק</string>
     <string name="unlock_notes">Unlock notes</string>
-    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or tap \"OK\" to skip exporting locked notes.</string>
+    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or skip exporting them.</string>
     <string name="note_content_locked">תוכן הפתקים נעול.</string>
     <string name="show_content">הראה תוכן</string>
     <string name="locking_warning">אזהרה: אם תשכח את הסיסמה של הפתקים, לא תוכל לשחזר אותה או לגשת לתוכן הפתקים יותר.</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -24,6 +24,8 @@
     <string name="text_note">פתק טקסט</string>
     <string name="lock_note">נעל פתק</string>
     <string name="unlock_note">בטל נעילת פתק</string>
+    <string name="unlock_notes">Unlock notes</string>
+    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or tap \"OK\" to skip exporting locked notes.</string>
     <string name="note_content_locked">תוכן הפתקים נעול.</string>
     <string name="show_content">הראה תוכן</string>
     <string name="locking_warning">אזהרה: אם תשכח את הסיסמה של הפתקים, לא תוכל לשחזר אותה או לגשת לתוכן הפתקים יותר.</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -24,6 +24,8 @@
     <string name="text_note">テキストメモ</string>
     <string name="lock_note">メモをロック</string>
     <string name="unlock_note">メモのロックを解除</string>
+    <string name="unlock_notes">Unlock notes</string>
+    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or tap \"OK\" to skip exporting locked notes.</string>
     <string name="note_content_locked">メモの内容がロックされています。</string>
     <string name="show_content">内容を表示</string>
     <string name="locking_warning">警告：メモのパスワードを忘れた場合、そのパスワードを復元したり、メモの内容にアクセスしたりすることはできなくなります。</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -25,7 +25,7 @@
     <string name="lock_note">メモをロック</string>
     <string name="unlock_note">メモのロックを解除</string>
     <string name="unlock_notes">Unlock notes</string>
-    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or tap \"OK\" to skip exporting locked notes.</string>
+    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or skip exporting them.</string>
     <string name="note_content_locked">メモの内容がロックされています。</string>
     <string name="show_content">内容を表示</string>
     <string name="locking_warning">警告：メモのパスワードを忘れた場合、そのパスワードを復元したり、メモの内容にアクセスしたりすることはできなくなります。</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -25,7 +25,7 @@
     <string name="lock_note">Lock note</string>
     <string name="unlock_note">Unlock note</string>
     <string name="unlock_notes">Unlock notes</string>
-    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or tap \"OK\" to skip exporting locked notes.</string>
+    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or skip exporting them.</string>
     <string name="note_content_locked">Pastabų turinys yra užrakintas.</string>
     <string name="show_content">Show content</string>
     <string name="locking_warning">ĮSPĖJIMAS: jei pamiršite užrašų slaptažodį, nebegalėsite jo atkurti ar pasiekti užrašų turinio.</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -24,6 +24,8 @@
     <string name="text_note">Tekstinis užrašas</string>
     <string name="lock_note">Lock note</string>
     <string name="unlock_note">Unlock note</string>
+    <string name="unlock_notes">Unlock notes</string>
+    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or tap \"OK\" to skip exporting locked notes.</string>
     <string name="note_content_locked">Pastabų turinys yra užrakintas.</string>
     <string name="show_content">Show content</string>
     <string name="locking_warning">ĮSPĖJIMAS: jei pamiršite užrašų slaptažodį, nebegalėsite jo atkurti ar pasiekti užrašų turinio.</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -24,6 +24,8 @@
     <string name="text_note">Text note</string>
     <string name="lock_note">Lock note</string>
     <string name="unlock_note">Unlock note</string>
+    <string name="unlock_notes">Unlock notes</string>
+    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or tap \"OK\" to skip exporting locked notes.</string>
     <string name="note_content_locked">The notes\' content is locked.</string>
     <string name="show_content">Show content</string>
     <string name="locking_warning">WARNING: If you forget the notes\' password, you won\'t be able to recover it or access the notes\' content anymore.</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -25,7 +25,7 @@
     <string name="lock_note">Lock note</string>
     <string name="unlock_note">Unlock note</string>
     <string name="unlock_notes">Unlock notes</string>
-    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or tap \"OK\" to skip exporting locked notes.</string>
+    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or skip exporting them.</string>
     <string name="note_content_locked">The notes\' content is locked.</string>
     <string name="show_content">Show content</string>
     <string name="locking_warning">WARNING: If you forget the notes\' password, you won\'t be able to recover it or access the notes\' content anymore.</string>

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -25,7 +25,7 @@
     <string name="lock_note">Lås notat</string>
     <string name="unlock_note">Lås opp notat</string>
     <string name="unlock_notes">Unlock notes</string>
-    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or tap \"OK\" to skip exporting locked notes.</string>
+    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or skip exporting them.</string>
     <string name="note_content_locked">Notatinnholdet er låst.</string>
     <string name="show_content">Vis innhold</string>
     <string name="locking_warning">ADVARSEL: Hvis du glemmer passordet til notatene, kan du ikke gjenopprette det eller få tilgang til notatenes innhold lenger.</string>

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -24,6 +24,8 @@
     <string name="text_note">Tekstnotat</string>
     <string name="lock_note">Lås notat</string>
     <string name="unlock_note">Lås opp notat</string>
+    <string name="unlock_notes">Unlock notes</string>
+    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or tap \"OK\" to skip exporting locked notes.</string>
     <string name="note_content_locked">Notatinnholdet er låst.</string>
     <string name="show_content">Vis innhold</string>
     <string name="locking_warning">ADVARSEL: Hvis du glemmer passordet til notatene, kan du ikke gjenopprette det eller få tilgang til notatenes innhold lenger.</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -24,7 +24,7 @@
     <string name="lock_note">Notitie vergrendelen</string>
     <string name="unlock_note">Notitie ontgrendelen</string>
     <string name="unlock_notes">Unlock notes</string>
-    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or tap \"OK\" to skip exporting locked notes.</string>
+    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or skip exporting them.</string>
     <string name="note_content_locked">De inhoud van deze notitie is vergrendeld.</string>
     <string name="show_content">Inhoud weergeven</string>
     <string name="locking_warning">WAARSCHUWING: Zonder het wachtwoord kan de inhoud van de notitie niet meer worden hersteld.</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -23,6 +23,8 @@
     <string name="text_note">Tekst</string>
     <string name="lock_note">Notitie vergrendelen</string>
     <string name="unlock_note">Notitie ontgrendelen</string>
+    <string name="unlock_notes">Unlock notes</string>
+    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or tap \"OK\" to skip exporting locked notes.</string>
     <string name="note_content_locked">De inhoud van deze notitie is vergrendeld.</string>
     <string name="show_content">Inhoud weergeven</string>
     <string name="locking_warning">WAARSCHUWING: Zonder het wachtwoord kan de inhoud van de notitie niet meer worden hersteld.</string>

--- a/app/src/main/res/values-pa-rPK/strings.xml
+++ b/app/src/main/res/values-pa-rPK/strings.xml
@@ -24,7 +24,7 @@
     <string name="lock_note">نوٹ تالؕا مارنا</string>
     <string name="unlock_note">نوٹ اُگھیڑو</string>
     <string name="unlock_notes">Unlock notes</string>
-    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or tap \"OK\" to skip exporting locked notes.</string>
+    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or skip exporting them.</string>
     <string name="note_content_locked">ایس نوٹ دی سمگاری تالؕا مارنی اے</string>
     <string name="show_content">سمگری ویکھو</string>
     <string name="locking_warning">چیتاونی: جےتسی نوٹ دا پاس‌ورڈ بھُل جاندے او، تاں فیر نوٹ دی سمگری لبھ نہیں سکدیاں۔</string>

--- a/app/src/main/res/values-pa-rPK/strings.xml
+++ b/app/src/main/res/values-pa-rPK/strings.xml
@@ -23,6 +23,8 @@
     <string name="text_note">لکھت دا نوٹ</string>
     <string name="lock_note">نوٹ تالؕا مارنا</string>
     <string name="unlock_note">نوٹ اُگھیڑو</string>
+    <string name="unlock_notes">Unlock notes</string>
+    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or tap \"OK\" to skip exporting locked notes.</string>
     <string name="note_content_locked">ایس نوٹ دی سمگاری تالؕا مارنی اے</string>
     <string name="show_content">سمگری ویکھو</string>
     <string name="locking_warning">چیتاونی: جےتسی نوٹ دا پاس‌ورڈ بھُل جاندے او، تاں فیر نوٹ دی سمگری لبھ نہیں سکدیاں۔</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -24,6 +24,8 @@
     <string name="text_note">Notatka tekstowa</string>
     <string name="lock_note">Zablokuj notatkę</string>
     <string name="unlock_note">Odblokuj notatkę</string>
+    <string name="unlock_notes">Unlock notes</string>
+    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or tap \"OK\" to skip exporting locked notes.</string>
     <string name="note_content_locked">Treść notatki jest zablokowana.</string>
     <string name="show_content">Pokaż zawartość</string>
     <string name="locking_warning">OSTRZEŻENIE: Jeśli zapomnisz hasła do notatki, nie będziesz już mógł/mogła jej odzyskać ani uzyskać dostępu do treści notatki.</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -25,7 +25,7 @@
     <string name="lock_note">Zablokuj notatkę</string>
     <string name="unlock_note">Odblokuj notatkę</string>
     <string name="unlock_notes">Unlock notes</string>
-    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or tap \"OK\" to skip exporting locked notes.</string>
+    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or skip exporting them.</string>
     <string name="note_content_locked">Treść notatki jest zablokowana.</string>
     <string name="show_content">Pokaż zawartość</string>
     <string name="locking_warning">OSTRZEŻENIE: Jeśli zapomnisz hasła do notatki, nie będziesz już mógł/mogła jej odzyskać ani uzyskać dostępu do treści notatki.</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -24,6 +24,8 @@
     <string name="text_note">Anotações</string>
     <string name="lock_note">Bloquear anotação</string>
     <string name="unlock_note">Desbloquear anotação</string>
+    <string name="unlock_notes">Unlock notes</string>
+    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or tap \"OK\" to skip exporting locked notes.</string>
     <string name="note_content_locked">O conteúdo da nota está bloqueado.</string>
     <string name="show_content">Mostrar conteúdo</string>
     <string name="locking_warning">AVISO: Caso você esqueça a senha, não conseguirá recuperá-la ou acessar o conteúdo da nota.</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -25,7 +25,7 @@
     <string name="lock_note">Bloquear anotação</string>
     <string name="unlock_note">Desbloquear anotação</string>
     <string name="unlock_notes">Unlock notes</string>
-    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or tap \"OK\" to skip exporting locked notes.</string>
+    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or skip exporting them.</string>
     <string name="note_content_locked">O conteúdo da nota está bloqueado.</string>
     <string name="show_content">Mostrar conteúdo</string>
     <string name="locking_warning">AVISO: Caso você esqueça a senha, não conseguirá recuperá-la ou acessar o conteúdo da nota.</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -25,7 +25,7 @@
     <string name="lock_note">Bloquear nota</string>
     <string name="unlock_note">Desbloquear nota</string>
     <string name="unlock_notes">Unlock notes</string>
-    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or tap \"OK\" to skip exporting locked notes.</string>
+    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or skip exporting them.</string>
     <string name="note_content_locked">O conteúdo da nota está bloqueado.</string>
     <string name="show_content">Mostrar conteúdo</string>
     <string name="locking_warning">AVISO: se esquecer a palavra-passe, não conseguirá aceder à nota nem recuperar o seu conteúdo.</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -24,6 +24,8 @@
     <string name="text_note">Nota de texto</string>
     <string name="lock_note">Bloquear nota</string>
     <string name="unlock_note">Desbloquear nota</string>
+    <string name="unlock_notes">Unlock notes</string>
+    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or tap \"OK\" to skip exporting locked notes.</string>
     <string name="note_content_locked">O conteúdo da nota está bloqueado.</string>
     <string name="show_content">Mostrar conteúdo</string>
     <string name="locking_warning">AVISO: se esquecer a palavra-passe, não conseguirá aceder à nota nem recuperar o seu conteúdo.</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -25,7 +25,7 @@
     <string name="lock_note">Blocaţi notița</string>
     <string name="unlock_note">Deblocaţi notița</string>
     <string name="unlock_notes">Unlock notes</string>
-    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or tap \"OK\" to skip exporting locked notes.</string>
+    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or skip exporting them.</string>
     <string name="note_content_locked">Conținutul notiței este blocat.</string>
     <string name="show_content">Afișați conținutul</string>
     <string name="locking_warning">ATENȚIE: Dacă uitați parola notițelor, nu o veți mai putea recupera și nici nu veți mai putea accesa conținutul notițele.</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -24,6 +24,8 @@
     <string name="text_note">Notiță text</string>
     <string name="lock_note">Blocaţi notița</string>
     <string name="unlock_note">Deblocaţi notița</string>
+    <string name="unlock_notes">Unlock notes</string>
+    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or tap \"OK\" to skip exporting locked notes.</string>
     <string name="note_content_locked">Conținutul notiței este blocat.</string>
     <string name="show_content">Afișați conținutul</string>
     <string name="locking_warning">ATENȚIE: Dacă uitați parola notițelor, nu o veți mai putea recupera și nici nu veți mai putea accesa conținutul notițele.</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -25,7 +25,7 @@
     <string name="lock_note">Блокировать заметку</string>
     <string name="unlock_note">Разблокировать заметку</string>
     <string name="unlock_notes">Unlock notes</string>
-    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or tap \"OK\" to skip exporting locked notes.</string>
+    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or skip exporting them.</string>
     <string name="note_content_locked">Содержимое заметки заблокировано.</string>
     <string name="show_content">Показывать содержание</string>
     <string name="locking_warning">ПРЕДУПРЕЖДЕНИЕ: если вы забудете пароль, то не сможете восстановить его или получить доступ к содержимому заметок.</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -24,6 +24,8 @@
     <string name="text_note">Текстовая заметка</string>
     <string name="lock_note">Блокировать заметку</string>
     <string name="unlock_note">Разблокировать заметку</string>
+    <string name="unlock_notes">Unlock notes</string>
+    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or tap \"OK\" to skip exporting locked notes.</string>
     <string name="note_content_locked">Содержимое заметки заблокировано.</string>
     <string name="show_content">Показывать содержание</string>
     <string name="locking_warning">ПРЕДУПРЕЖДЕНИЕ: если вы забудете пароль, то не сможете восстановить его или получить доступ к содержимому заметок.</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -25,7 +25,7 @@
     <string name="lock_note">Uzamknúť poznámku</string>
     <string name="unlock_note">Odomknúť poznámku</string>
     <string name="unlock_notes">Unlock notes</string>
-    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or tap \"OK\" to skip exporting locked notes.</string>
+    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or skip exporting them.</string>
     <string name="note_content_locked">Obsah poznámky je uzamknutý.</string>
     <string name="show_content">Zobraziť obsah</string>
     <string name="locking_warning">UPOZORNENIE: Ak zabudnete heslo poznámky, nebudete ho môcť obnoviť, ani sa už dostať k obsahu poznámky.</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -24,6 +24,8 @@
     <string name="text_note">Textová poznámka</string>
     <string name="lock_note">Uzamknúť poznámku</string>
     <string name="unlock_note">Odomknúť poznámku</string>
+    <string name="unlock_notes">Unlock notes</string>
+    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or tap \"OK\" to skip exporting locked notes.</string>
     <string name="note_content_locked">Obsah poznámky je uzamknutý.</string>
     <string name="show_content">Zobraziť obsah</string>
     <string name="locking_warning">UPOZORNENIE: Ak zabudnete heslo poznámky, nebudete ho môcť obnoviť, ani sa už dostať k obsahu poznámky.</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -24,8 +24,8 @@
     <string name="text_note">Textová poznámka</string>
     <string name="lock_note">Uzamknúť poznámku</string>
     <string name="unlock_note">Odomknúť poznámku</string>
-    <string name="unlock_notes">Unlock notes</string>
-    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or skip exporting them.</string>
+    <string name="unlock_notes">Odomknúť poznámky</string>
+    <string name="found_locked_notes_info">Nasledovné poznámky sú uzamknuté. Môžete ich buď odomknúť po jednom, alebo vynechať ich exportovanie.</string>
     <string name="note_content_locked">Obsah poznámky je uzamknutý.</string>
     <string name="show_content">Zobraziť obsah</string>
     <string name="locking_warning">UPOZORNENIE: Ak zabudnete heslo poznámky, nebudete ho môcť obnoviť, ani sa už dostať k obsahu poznámky.</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -24,7 +24,7 @@
     <string name="lock_note">Opomba glede zaklepanja</string>
     <string name="unlock_note">Opomba o odklepanju</string>
     <string name="unlock_notes">Unlock notes</string>
-    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or tap \"OK\" to skip exporting locked notes.</string>
+    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or skip exporting them.</string>
     <string name="note_content_locked">Zaklenjena vsebina opomb.</string>
     <string name="show_content">Prikaži vsebino</string>
     <string name="locking_warning">OPOZORILO: Če pozabite geslo za opombe, ga ne bo moč več obnoviti in dostopati do njihove vsebine.</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -23,6 +23,8 @@
     <string name="text_note">Opomba k besedilu</string>
     <string name="lock_note">Opomba glede zaklepanja</string>
     <string name="unlock_note">Opomba o odklepanju</string>
+    <string name="unlock_notes">Unlock notes</string>
+    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or tap \"OK\" to skip exporting locked notes.</string>
     <string name="note_content_locked">Zaklenjena vsebina opomb.</string>
     <string name="show_content">Prikaži vsebino</string>
     <string name="locking_warning">OPOZORILO: Če pozabite geslo za opombe, ga ne bo moč več obnoviti in dostopati do njihove vsebine.</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -23,6 +23,8 @@
     <string name="text_note">Текст напомене</string>
     <string name="lock_note">Закључај белешку</string>
     <string name="unlock_note">Откључај белешку</string>
+    <string name="unlock_notes">Unlock notes</string>
+    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or tap \"OK\" to skip exporting locked notes.</string>
     <string name="note_content_locked">Садржај белешки је закључан.</string>
     <string name="show_content">Прикажи садржај</string>
     <string name="locking_warning">УПОЗОРЕЊЕ: Ако заборавите лозинку за белешке, више нећете моћи да је повратите нити да приступите садржају белешки.</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -24,7 +24,7 @@
     <string name="lock_note">Закључај белешку</string>
     <string name="unlock_note">Откључај белешку</string>
     <string name="unlock_notes">Unlock notes</string>
-    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or tap \"OK\" to skip exporting locked notes.</string>
+    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or skip exporting them.</string>
     <string name="note_content_locked">Садржај белешки је закључан.</string>
     <string name="show_content">Прикажи садржај</string>
     <string name="locking_warning">УПОЗОРЕЊЕ: Ако заборавите лозинку за белешке, више нећете моћи да је повратите нити да приступите садржају белешки.</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -25,7 +25,7 @@
     <string name="lock_note">Lås</string>
     <string name="unlock_note">Lås upp</string>
     <string name="unlock_notes">Unlock notes</string>
-    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or tap \"OK\" to skip exporting locked notes.</string>
+    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or skip exporting them.</string>
     <string name="note_content_locked">Anteckningens innehåll är låst.</string>
     <string name="show_content">Visa innehåll</string>
     <string name="locking_warning">VARNING: Om du glömmer anteckningens lösenord så finns ingen möjlighet att återställa detta och du kommer således förlora åtkomsten till anteckningens innehåll.</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -24,6 +24,8 @@
     <string name="text_note">Anteckning</string>
     <string name="lock_note">Lås</string>
     <string name="unlock_note">Lås upp</string>
+    <string name="unlock_notes">Unlock notes</string>
+    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or tap \"OK\" to skip exporting locked notes.</string>
     <string name="note_content_locked">Anteckningens innehåll är låst.</string>
     <string name="show_content">Visa innehåll</string>
     <string name="locking_warning">VARNING: Om du glömmer anteckningens lösenord så finns ingen möjlighet att återställa detta och du kommer således förlora åtkomsten till anteckningens innehåll.</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -24,6 +24,8 @@
     <string name="text_note">โน็ตข้อความ</string>
     <string name="lock_note">ล็อกโน็ต</string>
     <string name="unlock_note">ปลดล็อกโน็ต</string>
+    <string name="unlock_notes">Unlock notes</string>
+    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or tap \"OK\" to skip exporting locked notes.</string>
     <string name="note_content_locked">ข้อมูลในโน็ตถูกล็อก</string>
     <string name="show_content">แสดงข้อมูล</string>
     <string name="locking_warning">คำเตือน: ถ้าคุณลืมรหัสผ่านของโน็ต คุณจะไม่สามารถกู้คืนหรือเข้าถึงโน็ตตัวนั้นได้อีกต่อไป</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -25,7 +25,7 @@
     <string name="lock_note">ล็อกโน็ต</string>
     <string name="unlock_note">ปลดล็อกโน็ต</string>
     <string name="unlock_notes">Unlock notes</string>
-    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or tap \"OK\" to skip exporting locked notes.</string>
+    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or skip exporting them.</string>
     <string name="note_content_locked">ข้อมูลในโน็ตถูกล็อก</string>
     <string name="show_content">แสดงข้อมูล</string>
     <string name="locking_warning">คำเตือน: ถ้าคุณลืมรหัสผ่านของโน็ต คุณจะไม่สามารถกู้คืนหรือเข้าถึงโน็ตตัวนั้นได้อีกต่อไป</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -24,6 +24,8 @@
     <string name="text_note">Metin notu</string>
     <string name="lock_note">Notu kilitle</string>
     <string name="unlock_note">Notun kilidini aç</string>
+    <string name="unlock_notes">Unlock notes</string>
+    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or tap \"OK\" to skip exporting locked notes.</string>
     <string name="note_content_locked">Notların içeriği kilitlendi.</string>
     <string name="show_content">İçeriği göster</string>
     <string name="locking_warning">UYARI: Notların parolasını unutursanız, onu kurtaramaz veya notların içeriğine artık erişemezsiniz.</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -25,7 +25,7 @@
     <string name="lock_note">Notu kilitle</string>
     <string name="unlock_note">Notun kilidini aç</string>
     <string name="unlock_notes">Unlock notes</string>
-    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or tap \"OK\" to skip exporting locked notes.</string>
+    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or skip exporting them.</string>
     <string name="note_content_locked">Notların içeriği kilitlendi.</string>
     <string name="show_content">İçeriği göster</string>
     <string name="locking_warning">UYARI: Notların parolasını unutursanız, onu kurtaramaz veya notların içeriğine artık erişemezsiniz.</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -24,6 +24,8 @@
     <string name="text_note">Текст нотатки</string>
     <string name="lock_note">Заблокувати нотатку</string>
     <string name="unlock_note">Розблокувати нотатку</string>
+    <string name="unlock_notes">Unlock notes</string>
+    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or tap \"OK\" to skip exporting locked notes.</string>
     <string name="note_content_locked">Вміст нотатки заблоковано.</string>
     <string name="show_content">Показати нотатку</string>
     <string name="locking_warning">ЗАСТЕРЕЖЕННЯ: Якщо ви забудете пароль, то більше не зможете його відновити або отримати доступ до вмісту нотаток.</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -25,7 +25,7 @@
     <string name="lock_note">Заблокувати нотатку</string>
     <string name="unlock_note">Розблокувати нотатку</string>
     <string name="unlock_notes">Unlock notes</string>
-    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or tap \"OK\" to skip exporting locked notes.</string>
+    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or skip exporting them.</string>
     <string name="note_content_locked">Вміст нотатки заблоковано.</string>
     <string name="show_content">Показати нотатку</string>
     <string name="locking_warning">ЗАСТЕРЕЖЕННЯ: Якщо ви забудете пароль, то більше не зможете його відновити або отримати доступ до вмісту нотаток.</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -23,6 +23,8 @@
     <string name="text_note">Ghi chú văn bản</string>
     <string name="lock_note">Khóa ghi chú</string>
     <string name="unlock_note">Mở khóa ghi chú</string>
+    <string name="unlock_notes">Unlock notes</string>
+    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or tap \"OK\" to skip exporting locked notes.</string>
     <string name="note_content_locked">Nội dung của ghi chú đã bị khóa.</string>
     <string name="show_content">Hiển thị nội dung</string>
     <string name="locking_warning">Cảnh Báo: Nếu bạn quên khi chú mật khẩu, bạn sẽ không thể nào lấy lại hay truy cập vào những ghi chú nữa</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -24,7 +24,7 @@
     <string name="lock_note">Khóa ghi chú</string>
     <string name="unlock_note">Mở khóa ghi chú</string>
     <string name="unlock_notes">Unlock notes</string>
-    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or tap \"OK\" to skip exporting locked notes.</string>
+    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or skip exporting them.</string>
     <string name="note_content_locked">Nội dung của ghi chú đã bị khóa.</string>
     <string name="show_content">Hiển thị nội dung</string>
     <string name="locking_warning">Cảnh Báo: Nếu bạn quên khi chú mật khẩu, bạn sẽ không thể nào lấy lại hay truy cập vào những ghi chú nữa</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -25,7 +25,7 @@
     <string name="lock_note">锁定笔记</string>
     <string name="unlock_note">解锁笔记</string>
     <string name="unlock_notes">Unlock notes</string>
-    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or tap \"OK\" to skip exporting locked notes.</string>
+    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or skip exporting them.</string>
     <string name="note_content_locked">笔记的内容被锁定。</string>
     <string name="show_content">显示内容</string>
     <string name="locking_warning">警告：如果您忘记了笔记的密码，您将无法恢复或访问笔记的内容。</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -24,6 +24,8 @@
     <string name="text_note">文本笔记</string>
     <string name="lock_note">锁定笔记</string>
     <string name="unlock_note">解锁笔记</string>
+    <string name="unlock_notes">Unlock notes</string>
+    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or tap \"OK\" to skip exporting locked notes.</string>
     <string name="note_content_locked">笔记的内容被锁定。</string>
     <string name="show_content">显示内容</string>
     <string name="locking_warning">警告：如果您忘记了笔记的密码，您将无法恢复或访问笔记的内容。</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -24,6 +24,8 @@
     <string name="text_note">文字筆記</string>
     <string name="lock_note">Lock note</string>
     <string name="unlock_note">解鎖筆記</string>
+    <string name="unlock_notes">Unlock notes</string>
+    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or tap \"OK\" to skip exporting locked notes.</string>
     <string name="note_content_locked">The notes\' content is locked.</string>
     <string name="show_content">Show content</string>
     <string name="locking_warning">WARNING: If you forget the notes\' password, you won\'t be able to recover it or access the notes\' content anymore.</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -25,7 +25,7 @@
     <string name="lock_note">Lock note</string>
     <string name="unlock_note">解鎖筆記</string>
     <string name="unlock_notes">Unlock notes</string>
-    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or tap \"OK\" to skip exporting locked notes.</string>
+    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or skip exporting them.</string>
     <string name="note_content_locked">The notes\' content is locked.</string>
     <string name="show_content">Show content</string>
     <string name="locking_warning">WARNING: If you forget the notes\' password, you won\'t be able to recover it or access the notes\' content anymore.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -23,6 +23,8 @@
     <string name="text_note">Text note</string>
     <string name="lock_note">Lock note</string>
     <string name="unlock_note">Unlock note</string>
+    <string name="unlock_notes">Unlock notes</string>
+    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or tap \"OK\" to skip exporting locked notes.</string>
     <string name="note_content_locked">The notes\' content is locked.</string>
     <string name="show_content">Show content</string>
     <string name="locking_warning">WARNING: If you forget the notes\' password, you won\'t be able to recover it or access the notes\' content anymore.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -24,7 +24,7 @@
     <string name="lock_note">Lock note</string>
     <string name="unlock_note">Unlock note</string>
     <string name="unlock_notes">Unlock notes</string>
-    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or tap \"OK\" to skip exporting locked notes.</string>
+    <string name="found_locked_notes_info">The following notes are locked. You can either unlock them one by one or skip exporting them.</string>
     <string name="note_content_locked">The notes\' content is locked.</string>
     <string name="show_content">Show content</string>
     <string name="locking_warning">WARNING: If you forget the notes\' password, you won\'t be able to recover it or access the notes\' content anymore.</string>


### PR DESCRIPTION
When using "Export all notes", a dialog is now shown with the list of locked notes that the user can unlock one by one. In the future, we could also check if the user used biometric auth for all notes and authenticate in one go.

**Preview:**

<img src="https://user-images.githubusercontent.com/36371707/225138256-90376d1e-20b5-4b6b-ac86-2bbb7a603266.png" width=264 /> <img src="https://user-images.githubusercontent.com/36371707/225138238-63f8f8d7-b442-4cd3-9f68-501f5c7a7234.png" width=264 />


We can also redesign this dialog to display all notes here with checkboxes so the user can select which notes to export. 