### PR TITLE
Use MyMovementMethod on hotfix fixing crash on selection (SDK<=23)

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/notes/pro/activities/MainActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/notes/pro/activities/MainActivity.kt
@@ -243,7 +243,7 @@ class MainActivity : SimpleActivity() {
         super.onActionModeStarted(mode)
         if (wasInit) {
             currentNotesView()?.apply {
-                if (config.clickableLinks || movementMethod is LinkMovementMethod) {
+                if (config.clickableLinks || movementMethod is LinkMovementMethod || movementMethod is MyMovementMethod) {
                     movementMethod = ArrowKeyMovementMethod.getInstance()
                     noteViewWithTextSelected = this
                 }
@@ -254,7 +254,7 @@ class MainActivity : SimpleActivity() {
     override fun onActionModeFinished(mode: ActionMode?) {
         super.onActionModeFinished(mode)
         if (config.clickableLinks) {
-            noteViewWithTextSelected?.movementMethod = LinkMovementMethod.getInstance()
+            noteViewWithTextSelected?.movementMethod = MyMovementMethod.getInstance()
         }
     }
 


### PR DESCRIPTION
- fixes #621
- hotfix causing the issue implemented in 1741070686d83745762bf285455aac985f10fca1
- for further explanation read [this comment](https://github.com/SimpleMobileTools/Simple-Notes/issues/621#issuecomment-1555908584)

Tested on Android 13 (SDK 33, LineageOS `20-20230410-microG-FP4`) on a Fairphone 4

It might be that the change in line 246 is not required because `MyMovementMethod` might not trigger the issue fixed by this workaround. But because I cannot test this, I want to make sure that the workaround is still in place *if* that is the case.