### PR TITLE
Add hints for search toolbar buttons

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/notes/pro/activities/MainActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/notes/pro/activities/MainActivity.kt
@@ -27,6 +27,7 @@ import android.webkit.WebViewClient
 import android.widget.ImageView
 import android.widget.TextView
 import android.widget.Toast
+import androidx.appcompat.widget.TooltipCompat
 import com.simplemobiletools.commons.dialogs.*
 import com.simplemobiletools.commons.extensions.*
 import com.simplemobiletools.commons.helpers.*
@@ -458,16 +459,28 @@ class MainActivity : SimpleActivity() {
             searchTextChanged(it)
         }
 
-        searchPrevBtn.setOnClickListener {
-            goToPrevSearchResult()
+        searchPrevBtn.run {
+            setOnClickListener {
+                goToPrevSearchResult()
+            }
+            contentDescription = getString(R.string.previous)
+            TooltipCompat.setTooltipText(this, getString(R.string.previous))
         }
 
-        searchNextBtn.setOnClickListener {
-            goToNextSearchResult()
+        searchNextBtn.run {
+            setOnClickListener {
+                goToNextSearchResult()
+            }
+            contentDescription = getString(R.string.next)
+            TooltipCompat.setTooltipText(this, getString(R.string.next))
         }
 
-        searchClearBtn.setOnClickListener {
-            closeSearch()
+        searchClearBtn.run {
+            setOnClickListener {
+                closeSearch()
+            }
+            contentDescription = getString(R.string.cancel)
+            TooltipCompat.setTooltipText(this, getString(R.string.cancel))
         }
 
         view_pager.onPageChangeListener {


### PR DESCRIPTION
Addresses https://github.com/SimpleMobileTools/Simple-Notes/issues/632.

Not sure if that issue describes accessibility labels or hints. I added both, seems useful anyway. I used strings from the commons repo. Let me know if those make sense or if you want to create different custom ones to describe these buttons.