### PR TITLE
Fix 353: Change gravity internally from Left and Right to Start and End

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/notes/pro/activities/SettingsActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/notes/pro/activities/SettingsActivity.kt
@@ -5,6 +5,8 @@ import android.net.Uri
 import android.os.Bundle
 import android.view.Menu
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.core.text.TextUtilsCompat
+import androidx.core.view.ViewCompat
 import com.simplemobiletools.commons.dialogs.RadioGroupDialog
 import com.simplemobiletools.commons.extensions.*
 import com.simplemobiletools.commons.helpers.*
@@ -222,13 +224,8 @@ class SettingsActivity : SimpleActivity() {
     private fun setupGravity() {
         settings_gravity.text = getGravityText()
         settings_gravity_holder.setOnClickListener {
-            val items = arrayListOf(
-                RadioItem(GRAVITY_LEFT, getString(R.string.left)),
-                RadioItem(GRAVITY_CENTER, getString(R.string.center)),
-                RadioItem(GRAVITY_RIGHT, getString(R.string.right))
-            )
-
-            RadioGroupDialog(this@SettingsActivity, items, config.gravity) {
+            val items = listOf(GRAVITY_START, GRAVITY_CENTER, GRAVITY_END).map { RadioItem(it, getGravityOptionLabel(it)) }
+            RadioGroupDialog(this@SettingsActivity, ArrayList(items), config.gravity) {
                 config.gravity = it as Int
                 settings_gravity.text = getGravityText()
                 updateWidgets()
@@ -236,13 +233,24 @@ class SettingsActivity : SimpleActivity() {
         }
     }
 
-    private fun getGravityText() = getString(
-        when (config.gravity) {
-            GRAVITY_LEFT -> R.string.left
-            GRAVITY_CENTER -> R.string.center
-            else -> R.string.right
+    private fun getGravityOptionLabel(gravity: Int): String {
+        val leftToRightDirection = TextUtilsCompat.getLayoutDirectionFromLocale(Locale.getDefault()) == ViewCompat.LAYOUT_DIRECTION_LTR
+        val leftRightLabels = listOf(R.string.left, R.string.right)
+        val startEndLabels = if (leftToRightDirection) {
+            leftRightLabels
+        } else {
+            leftRightLabels.reversed()
         }
-    )
+        return getString(
+            when (gravity) {
+                GRAVITY_START -> startEndLabels.first()
+                GRAVITY_CENTER -> R.string.center
+                else -> startEndLabels.last()
+            }
+        )
+    }
+
+    private fun getGravityText() = getGravityOptionLabel(config.gravity)
 
     private fun setupCursorPlacement() {
         settings_cursor_placement.isChecked = config.placeCursorToEnd

--- a/app/src/main/kotlin/com/simplemobiletools/notes/pro/adapters/WidgetAdapter.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/notes/pro/adapters/WidgetAdapter.kt
@@ -6,8 +6,6 @@ import android.graphics.Paint
 import android.view.View
 import android.widget.RemoteViews
 import android.widget.RemoteViewsService
-import com.google.gson.Gson
-import com.google.gson.reflect.TypeToken
 import com.simplemobiletools.commons.extensions.adjustAlpha
 import com.simplemobiletools.commons.extensions.setText
 import com.simplemobiletools.commons.extensions.setTextSize
@@ -95,8 +93,8 @@ class WidgetAdapter(val context: Context, val intent: Intent) : RemoteViewsServi
         return when {
             gravity == GRAVITY_CENTER && isMonospaced -> R.id.widget_text_center_monospace
             gravity == GRAVITY_CENTER -> R.id.widget_text_center
-            gravity == GRAVITY_RIGHT && isMonospaced -> R.id.widget_text_right_monospace
-            gravity == GRAVITY_RIGHT -> R.id.widget_text_right
+            gravity == GRAVITY_END && isMonospaced -> R.id.widget_text_right_monospace
+            gravity == GRAVITY_END -> R.id.widget_text_right
             isMonospaced -> R.id.widget_text_left_monospace
             else -> R.id.widget_text_left
         }
@@ -109,8 +107,8 @@ class WidgetAdapter(val context: Context, val intent: Intent) : RemoteViewsServi
         return when {
             gravity == GRAVITY_CENTER && isMonospaced -> R.id.checklist_text_center_monospace
             gravity == GRAVITY_CENTER -> R.id.checklist_text_center
-            gravity == GRAVITY_RIGHT && isMonospaced -> R.id.checklist_text_right_monospace
-            gravity == GRAVITY_RIGHT -> R.id.checklist_text_right
+            gravity == GRAVITY_END && isMonospaced -> R.id.checklist_text_right_monospace
+            gravity == GRAVITY_END -> R.id.checklist_text_right
             isMonospaced -> R.id.checklist_text_left_monospace
             else -> R.id.checklist_text_left
         }

--- a/app/src/main/kotlin/com/simplemobiletools/notes/pro/helpers/Config.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/notes/pro/helpers/Config.kt
@@ -1,6 +1,5 @@
 package com.simplemobiletools.notes.pro.helpers
 
-import android.annotation.SuppressLint
 import android.content.Context
 import android.os.Environment
 import android.view.Gravity
@@ -41,7 +40,7 @@ class Config(context: Context) : BaseConfig(context) {
         set(showWordCount) = prefs.edit().putBoolean(SHOW_WORD_COUNT, showWordCount).apply()
 
     var gravity: Int
-        get() = prefs.getInt(GRAVITY, GRAVITY_LEFT)
+        get() = prefs.getInt(GRAVITY, GRAVITY_START)
         set(size) = prefs.edit().putInt(GRAVITY, size).apply()
 
     var currentNoteId: Long
@@ -80,11 +79,10 @@ class Config(context: Context) : BaseConfig(context) {
         get() = prefs.getBoolean(MOVE_DONE_CHECKLIST_ITEMS, false)
         set(moveDoneChecklistItems) = prefs.edit().putBoolean(MOVE_DONE_CHECKLIST_ITEMS, moveDoneChecklistItems).apply()
 
-    @SuppressLint("RtlHardcoded")
     fun getTextGravity() = when (gravity) {
         GRAVITY_CENTER -> Gravity.CENTER_HORIZONTAL
-        GRAVITY_RIGHT -> Gravity.RIGHT
-        else -> Gravity.LEFT
+        GRAVITY_END -> Gravity.END
+        else -> Gravity.START
     }
 
     var fontSizePercentage: Int

--- a/app/src/main/kotlin/com/simplemobiletools/notes/pro/helpers/Constants.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/notes/pro/helpers/Constants.kt
@@ -40,9 +40,9 @@ const val EXPORT_MIME_TYPE = "text/plain"
 const val ADD_NEW_CHECKLIST_ITEMS_TOP = "add_new_checklist_items_top"
 
 // gravity
-const val GRAVITY_LEFT = 0
+const val GRAVITY_START = 0
 const val GRAVITY_CENTER = 1
-const val GRAVITY_RIGHT = 2
+const val GRAVITY_END = 2
 
 // mime types
 const val MIME_TEXT_PLAIN = "text/plain"


### PR DESCRIPTION
Replaces `Left` and `Right` gravity with the proper `Start` and `End` equivalents to support RTL languages.

Fixes #353: Aligning RTL text isn't working correctly.

Before the change, notes and checklists in the app were aligned to one side, either Left or Right (regardless of LTR or RTL of the language). This was inconsistent with the widgets, which were already using Start and End gravity (`widget_text_layout.xml`).

After the change to Start / End, both LTR and RTL languages can coexist in the same note / checklist.

<img src="https://github.com/SimpleMobileTools/Simple-Notes/assets/1280433/e1978431-1ecc-4736-b5e5-e03c760cfbf4" width="200px" />
<img src="https://github.com/SimpleMobileTools/Simple-Notes/assets/1280433/c05f1970-3a8c-40f8-bfa4-b6fe3a4dceb6" width="200px" />

The Alignment setting should not be needed anymore for RTL as it works out of the box. It still uses the Left & Right terms for simplicity and even swaps the labels for RTL languages. TBD if renaming them to something like "Default" and "Inverted" would make more sense.

<img src="https://github.com/SimpleMobileTools/Simple-Notes/assets/1280433/5b722b89-da28-4ad4-a6bd-6532aa6155dc" width="200px" />
<img src="https://github.com/SimpleMobileTools/Simple-Notes/assets/1280433/ad00e87e-332d-4460-a45f-64dd43b07532" width="200px" />
