### PR TITLE
Update targetSdkVersion to 34

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -13,12 +13,12 @@ if (keystorePropertiesFile.exists()) {
 }
 
 android {
-    compileSdk 33
+    compileSdk 34
 
     defaultConfig {
         applicationId "com.simplemobiletools.notes.pro"
         minSdkVersion 23
-        targetSdkVersion 33
+        targetSdkVersion 34
         versionCode 107
         versionName "6.15.6"
         setProperty("archivesBaseName", "notes")

--- a/app/src/main/kotlin/com/simplemobiletools/notes/pro/adapters/WidgetAdapter.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/notes/pro/adapters/WidgetAdapter.kt
@@ -126,7 +126,7 @@ class WidgetAdapter(val context: Context, val intent: Intent) : RemoteViewsServi
         val noteId = intent.getLongExtra(NOTE_ID, 0L)
         note = context.notesDB.getNoteWithId(noteId)
         if (note?.type == NoteType.TYPE_CHECKLIST) {
-            checklistItems = note!!.getNoteStoredValue(context)?.let { Json.decodeFromString(it) } ?: mutableListOf()
+            checklistItems = note!!.getNoteStoredValue(context)?.ifEmpty { "[]" }?.let { Json.decodeFromString(it) } ?: mutableListOf()
 
             // checklist title can be null only because of the glitch in upgrade to 6.6.0, remove this check in the future
             checklistItems = checklistItems.filter { it.title != null }.toMutableList() as ArrayList<ChecklistItem>


### PR DESCRIPTION
There are 2 known issues with this update:
- Max font scaling does not look well in the PagerTabStrip
- Not sure if caused by the update, updating file linked to the note sometimes fails with SecurityException

No other changes from these lists affects this app:
- https://developer.android.com/about/versions/14/behavior-changes-all
- https://developer.android.com/about/versions/14/behavior-changes-14

This also fixes a crash when widget checklist is empty.