### PR TITLE
Fix crash when restoring state on TextFragment

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/notes/pro/fragments/TextFragment.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/notes/pro/fragments/TextFragment.kt
@@ -131,7 +131,7 @@ class TextFragment : NoteFragment() {
         if (savedInstanceState != null && note != null && savedInstanceState.containsKey(TEXT)) {
             skipTextUpdating = true
             val newText = savedInstanceState.getString(TEXT) ?: ""
-            innerBinding.root.findViewById<MyTextView>(R.id.text_note_view).text = newText
+            innerBinding.root.findViewById<TextView>(R.id.text_note_view).text = newText
         }
     }
 


### PR DESCRIPTION
`onViewStateRestored()` in TextFragment crashed with `ClassCastException`, because layout has `MyEditText` with id `text_note_view` and not `MyTextView`. This has now been changed to `TextView` to ensure less breaking in the future and since only `text` was changed, this is enough.

This happened when viewing notes and causing configuration change or something else that would cause the state to be restored.