### PR TITLE
Fixed showing note picker on opening from shortcut (#679)

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/notes/pro/activities/MainActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/notes/pro/activities/MainActivity.kt
@@ -98,18 +98,22 @@ class MainActivity : SimpleActivity() {
         searchNextBtn = findViewById(com.simplemobiletools.commons.R.id.search_next)
         searchClearBtn = findViewById(com.simplemobiletools.commons.R.id.search_clear)
 
-        initViewPager(intent.getLongExtra(OPEN_NOTE_ID, -1L))
+        val noteToOpen = intent.getLongExtra(OPEN_NOTE_ID, -1L)
+        initViewPager(noteToOpen)
         binding.pagerTabStrip.drawFullUnderline = false
         val textSize = getPercentageFontSize()
         binding.pagerTabStrip.setTextSize(TypedValue.COMPLEX_UNIT_PX, textSize)
         binding.pagerTabStrip.layoutParams.height =
             (textSize + resources.getDimension(com.simplemobiletools.commons.R.dimen.medium_margin) * 2).toInt()
         (binding.pagerTabStrip.layoutParams as ViewPager.LayoutParams).isDecor = true
+
+        val hasNoIntent = intent.action.isNullOrEmpty() && noteToOpen == -1L
+
         checkWhatsNewDialog()
         checkIntents(intent)
 
         storeStateVariables()
-        if (config.showNotePicker && savedInstanceState == null) {
+        if (config.showNotePicker && savedInstanceState == null && hasNoIntent) {
             displayOpenNoteDialog()
         }
 


### PR DESCRIPTION
Fixes #679

The problem occurred for all types of shortcuts, so this fix is for all of them.

**Before:**

https://github.com/SimpleMobileTools/Simple-Notes/assets/85929121/6d4f6064-10f8-4de3-8927-de94bfeeed00

**After:**

https://github.com/SimpleMobileTools/Simple-Notes/assets/85929121/4b229713-80ca-4087-b798-358ccb3b39e2